### PR TITLE
Add more info to reflector debug logs 

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/informers/cache/Reflector.java
@@ -137,7 +137,14 @@ public class Reflector<T extends HasMetadata, L extends KubernetesResourceList<T
         throw new KubernetesClientException("Unrecognized resource");  
       }
       if (log.isDebugEnabled()) {
-        log.debug("Event received {} {} resourceVersion {}", action.name(), resource.getKind(), resource.getMetadata().getResourceVersion());
+        log.debug(
+          "Event received {} {} {}: resourceVersion {}, resource: {}",
+          action.name(),
+          resource.getKind(),
+          resource.getMetadata().getName(),
+          resource.getMetadata().getResourceVersion(),
+          resource
+        );
       }
       switch (action) {
         case ERROR:


### PR DESCRIPTION
The current logs don't have much info, not even the name of the resource
>2022-07-22 17:37:58.648  [OkHttp https://172.19.128.1/...] DEBUG i.f.k.c.informers.cache.Reflector - Event received MODIFIED SupervisorAction resourceVersion 10849001396
2022-07-22 17:37:58.673  [OkHttp https://172.19.128.1/...] DEBUG i.f.k.c.informers.cache.Reflector - Event received MODIFIED SupervisorAction resourceVersion 10849001409

The bug where the readinessClient doesn't see that a supervisorAction has finished was reproduced, and the resource version of the finished supervisorAction didn't appear in the logs, which seems to imply that our theory that the reflector doesn't see the event is correct, but I'm hoping to confirm a bit better by adding some more info here.

Unfortunately `getStatus` isn't an option on this version of the resource, and I'm not sure how much else we'll get by logging the full resource. Just the name would be helpful enough if we're concerned about this being too much in the logs, though few things have this debug logging turned on