### PR TITLE
Upload sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1306,5 +1306,21 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>blazar-sources</id>
+      <activation>
+        <property>
+          <name>env.BLAZAR_COORDINATES</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
`maven-source-plugin` was setup to run under the `release` profile. We use a custom release/deploy system, so let's just duplicate the `maven-source-plugin` under a specific profile so that we get source JARs.