### PR TITLE
feat: Added support for autoscaling v2 api.

### DIFF
--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoscalingAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/AutoscalingAPIGroupClient.java
@@ -41,4 +41,9 @@ public class AutoscalingAPIGroupClient extends BaseClient implements Autoscaling
   public V2beta2AutoscalingAPIGroupDSL v2beta2() {
     return adapt(V2beta2AutoscalingAPIGroupClient.class);
   }
+
+  @Override
+  public V2AutoscalingAPIGroupDSL v2() {
+    return adapt(V2AutoscalingAPIGroupClient.class);
+  }
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V2AutoscalingAPIGroupClient.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V2AutoscalingAPIGroupClient.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.kubernetes.client;
+
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
+
+public class V2AutoscalingAPIGroupClient extends BaseClient implements V2AutoscalingAPIGroupDSL {
+
+  public V2AutoscalingAPIGroupClient() {
+    super();
+  }
+
+  public V2AutoscalingAPIGroupClient(ClientContext clientContext) {
+    super(clientContext);
+  }
+
+  @Override
+  public MixedOperation<HorizontalPodAutoscaler, HorizontalPodAutoscalerList, Resource<HorizontalPodAutoscaler>> horizontalPodAutoscalers() {
+    return Handlers.getOperation(HorizontalPodAutoscaler.class, HorizontalPodAutoscalerList.class, this);
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V2AutoscalingAPIGroupDSL.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V2AutoscalingAPIGroupDSL.java
@@ -13,18 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.fabric8.kubernetes.client;
 
-package io.fabric8.kubernetes.client.dsl;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler;
+import io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList;
+import io.fabric8.kubernetes.client.dsl.MixedOperation;
+import io.fabric8.kubernetes.client.dsl.Resource;
 
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.V1AutoscalingAPIGroupDSL;
-import io.fabric8.kubernetes.client.V2beta1AutoscalingAPIGroupDSL;
-import io.fabric8.kubernetes.client.V2beta2AutoscalingAPIGroupDSL;
-import io.fabric8.kubernetes.client.V2AutoscalingAPIGroupDSL;
-
-public interface AutoscalingAPIGroupDSL extends Client {
-  V1AutoscalingAPIGroupDSL v1();
-  V2beta1AutoscalingAPIGroupDSL v2beta1();
-  V2beta2AutoscalingAPIGroupDSL v2beta2();
-  V2AutoscalingAPIGroupDSL v2();
+public interface V2AutoscalingAPIGroupDSL extends Client {
+  MixedOperation<HorizontalPodAutoscaler, HorizontalPodAutoscalerList, Resource<HorizontalPodAutoscaler>> horizontalPodAutoscalers();
 }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V2AutoscalingAPIGroupExtensionAdapter.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/V2AutoscalingAPIGroupExtensionAdapter.java
@@ -13,18 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.fabric8.kubernetes.client;
 
-package io.fabric8.kubernetes.client.dsl;
+public class V2AutoscalingAPIGroupExtensionAdapter extends APIGroupExtensionAdapter<V2AutoscalingAPIGroupClient> {
 
-import io.fabric8.kubernetes.client.Client;
-import io.fabric8.kubernetes.client.V1AutoscalingAPIGroupDSL;
-import io.fabric8.kubernetes.client.V2beta1AutoscalingAPIGroupDSL;
-import io.fabric8.kubernetes.client.V2beta2AutoscalingAPIGroupDSL;
-import io.fabric8.kubernetes.client.V2AutoscalingAPIGroupDSL;
+  @Override
+  protected String getAPIGroupName() {
+    return "autoscaling/v2";
+  }
 
-public interface AutoscalingAPIGroupDSL extends Client {
-  V1AutoscalingAPIGroupDSL v1();
-  V2beta1AutoscalingAPIGroupDSL v2beta1();
-  V2beta2AutoscalingAPIGroupDSL v2beta2();
-  V2AutoscalingAPIGroupDSL v2();
+  @Override
+  public Class<V2AutoscalingAPIGroupClient> getExtensionType() {
+    return V2AutoscalingAPIGroupClient.class;
+  }
+
+  @Override
+  protected V2AutoscalingAPIGroupClient newInstance(Client client) {
+    return new V2AutoscalingAPIGroupClient(client);
+  }
+
 }

--- a/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
+++ b/kubernetes-client/src/main/resources/META-INF/services/io.fabric8.kubernetes.client.ExtensionAdapter
@@ -24,6 +24,7 @@ io.fabric8.kubernetes.client.AuthorizationAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V1AutoscalingAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V2beta1AutoscalingAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V2beta2AutoscalingAPIGroupExtensionAdapter
+io.fabric8.kubernetes.client.V2AutoscalingAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.BatchAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V1BatchAPIGroupExtensionAdapter
 io.fabric8.kubernetes.client.V1beta1BatchAPIGroupExtensionAdapter

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/cmd/generate/generate.go
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/cmd/generate/generate.go
@@ -24,6 +24,7 @@ import (
   "k8s.io/apimachinery/pkg/api/resource"
   apimachineryversion "k8s.io/apimachinery/pkg/version"
 
+  autoscalingapiv2 "k8s.io/api/autoscaling/v2"
   autoscalingapiv1 "k8s.io/api/autoscaling/v1"
   autoscalingapiv2beta1 "k8s.io/api/autoscaling/v2beta1"
   autoscalingapiv2beta2 "k8s.io/api/autoscaling/v2beta2"
@@ -58,6 +59,8 @@ type Schema struct {
   Quantity                                 resource.Quantity
 
   Scale                                    autoscalingapiv1.Scale
+  V2HorizontalPodAutoscaler                autoscalingapiv2.HorizontalPodAutoscaler
+  V2HorizontalPodAutoscalerList            autoscalingapiv2.HorizontalPodAutoscalerList
   V1HorizontalPodAutoscaler                autoscalingapiv1.HorizontalPodAutoscaler
   V1HorizontalPodAutoscalerList            autoscalingapiv1.HorizontalPodAutoscalerList
   V2beta1HorizontalPodAutoscaler           autoscalingapiv2beta1.HorizontalPodAutoscaler
@@ -76,6 +79,7 @@ func main() {
     {"k8s.io/api/autoscaling/v2beta2", "autoscaling", "io.fabric8.kubernetes.api.model.autoscaling.v2beta2", "kubernetes_autoscaling_v2beta2_", true},
     {"k8s.io/api/autoscaling/v2beta1", "autoscaling", "io.fabric8.kubernetes.api.model.autoscaling.v2beta1", "kubernetes_autoscaling_v2beta1_", true},
     {"k8s.io/api/autoscaling/v1", "autoscaling", "io.fabric8.kubernetes.api.model.autoscaling.v1", "kubernetes_autoscaling_v1_", true},
+    {"k8s.io/api/autoscaling/v2", "autoscaling", "io.fabric8.kubernetes.api.model.autoscaling.v2", "kubernetes_autoscaling_v2_", true},
   }
 
   typeMap := map[reflect.Type]reflect.Type{

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
@@ -145,33 +145,33 @@ public class KubeSchema {
     /**
      * 
      * @param listOptions
-     * @param v1HorizontalPodAutoscalerList
      * @param aPIGroupList
-     * @param patchOptions
-     * @param deleteOptions
-     * @param quantity
-     * @param v2beta2HorizontalPodAutoscalerList
      * @param baseKubernetesList
      * @param scale
      * @param updateOptions
      * @param v1HorizontalPodAutoscaler
-     * @param createOptions
      * @param patch
+     * @param v2beta1HorizontalPodAutoscalerList
+     * @param v2beta1HorizontalPodAutoscaler
+     * @param rootPaths
+     * @param info
+     * @param v1HorizontalPodAutoscalerList
+     * @param patchOptions
+     * @param deleteOptions
+     * @param quantity
+     * @param v2beta2HorizontalPodAutoscalerList
+     * @param v2HorizontalPodAutoscaler
+     * @param createOptions
      * @param aPIGroup
      * @param typeMeta
-     * @param v2beta1HorizontalPodAutoscalerList
      * @param v2beta2HorizontalPodAutoscaler
-     * @param v2beta1HorizontalPodAutoscaler
-     * @param v2HorizontalPodAutoscaler
      * @param v2HorizontalPodAutoscalerList
      * @param objectMeta
-     * @param rootPaths
      * @param getOptions
      * @param time
-     * @param info
      * @param status
      */
-    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, BaseKubernetesList baseKubernetesList, CreateOptions createOptions, DeleteOptions deleteOptions, GetOptions getOptions, Info info, ListOptions listOptions, io.fabric8.kubernetes.api.model.ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, Quantity quantity, RootPaths rootPaths, Scale scale, Status status, String time, TypeMeta typeMeta, UpdateOptions updateOptions, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscaler v1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerList v1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscaler v2beta1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscalerList v2beta1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscaler v2beta2HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList v2beta2HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler v2HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList v2HorizontalPodAutoscalerList) {
+    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, BaseKubernetesList baseKubernetesList, CreateOptions createOptions, DeleteOptions deleteOptions, GetOptions getOptions, Info info, ListOptions listOptions, io.fabric8.kubernetes.api.model.ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, Quantity quantity, RootPaths rootPaths, Scale scale, Status status, String time, TypeMeta typeMeta, UpdateOptions updateOptions, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscaler v1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerList v1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler v2HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList v2HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscaler v2beta1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscalerList v2beta1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscaler v2beta2HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList v2beta2HorizontalPodAutoscalerList) {
         super();
         this.aPIGroup = aPIGroup;
         this.aPIGroupList = aPIGroupList;
@@ -193,12 +193,12 @@ public class KubeSchema {
         this.updateOptions = updateOptions;
         this.v1HorizontalPodAutoscaler = v1HorizontalPodAutoscaler;
         this.v1HorizontalPodAutoscalerList = v1HorizontalPodAutoscalerList;
+        this.v2HorizontalPodAutoscaler = v2HorizontalPodAutoscaler;
+        this.v2HorizontalPodAutoscalerList = v2HorizontalPodAutoscalerList;
         this.v2beta1HorizontalPodAutoscaler = v2beta1HorizontalPodAutoscaler;
         this.v2beta1HorizontalPodAutoscalerList = v2beta1HorizontalPodAutoscalerList;
         this.v2beta2HorizontalPodAutoscaler = v2beta2HorizontalPodAutoscaler;
         this.v2beta2HorizontalPodAutoscalerList = v2beta2HorizontalPodAutoscalerList;
-        this.v2HorizontalPodAutoscaler = v2HorizontalPodAutoscaler;
-        this.v2HorizontalPodAutoscalerList = v2HorizontalPodAutoscalerList;
     }
 
     @JsonProperty("APIGroup")
@@ -401,6 +401,26 @@ public class KubeSchema {
         this.v1HorizontalPodAutoscalerList = v1HorizontalPodAutoscalerList;
     }
 
+    @JsonProperty("V2HorizontalPodAutoscaler")
+    public io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler getV2HorizontalPodAutoscaler() {
+        return v2HorizontalPodAutoscaler;
+    }
+
+    @JsonProperty("V2HorizontalPodAutoscaler")
+    public void setV2HorizontalPodAutoscaler(io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler v2HorizontalPodAutoscaler) {
+        this.v2HorizontalPodAutoscaler = v2HorizontalPodAutoscaler;
+    }
+
+    @JsonProperty("V2HorizontalPodAutoscalerList")
+    public io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList getV2HorizontalPodAutoscalerList() {
+        return v2HorizontalPodAutoscalerList;
+    }
+
+    @JsonProperty("V2HorizontalPodAutoscalerList")
+    public void setV2HorizontalPodAutoscalerList(io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList v2HorizontalPodAutoscalerList) {
+        this.v2HorizontalPodAutoscalerList = v2HorizontalPodAutoscalerList;
+    }
+
     @JsonProperty("V2beta1HorizontalPodAutoscaler")
     public io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscaler getV2beta1HorizontalPodAutoscaler() {
         return v2beta1HorizontalPodAutoscaler;
@@ -431,15 +451,6 @@ public class KubeSchema {
         this.v2beta2HorizontalPodAutoscaler = v2beta2HorizontalPodAutoscaler;
     }
 
-  @JsonProperty("V2HorizontalPodAutoscaler")
-  public io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler getV2HorizontalPodAutoscaler() {
-    return v2HorizontalPodAutoscaler;
-  }
-
-  @JsonProperty("V2HorizontalPodAutoscaler")
-  public void setV2HorizontalPodAutoscaler(io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler v2HorizontalPodAutoscaler) {
-    this.v2HorizontalPodAutoscaler = v2HorizontalPodAutoscaler;
-  }
     @JsonProperty("V2beta2HorizontalPodAutoscalerList")
     public io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList getV2beta2HorizontalPodAutoscalerList() {
         return v2beta2HorizontalPodAutoscalerList;
@@ -448,16 +459,6 @@ public class KubeSchema {
     @JsonProperty("V2beta2HorizontalPodAutoscalerList")
     public void setV2beta2HorizontalPodAutoscalerList(io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList v2beta2HorizontalPodAutoscalerList) {
         this.v2beta2HorizontalPodAutoscalerList = v2beta2HorizontalPodAutoscalerList;
-    }
-
-    @JsonProperty("V2HorizontalPodAutoscalerList")
-    public io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList getV2HorizontalPodAutoscalerList() {
-        return v2HorizontalPodAutoscalerList;
-    }
-
-    @JsonProperty("V2HorizontalPodAutoscalerList")
-    public void setV2HorizontalPodAutoscalerList(io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList v2HorizontalPodAutoscalerList) {
-        this.v2HorizontalPodAutoscalerList = v2HorizontalPodAutoscalerList;
     }
 
     @JsonAnyGetter

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/KubeSchema.java
@@ -53,6 +53,8 @@ import lombok.experimental.Accessors;
     "UpdateOptions",
     "V1HorizontalPodAutoscaler",
     "V1HorizontalPodAutoscalerList",
+    "V2HorizontalPodAutoscaler",
+    "V2HorizontalPodAutoscalerList",
     "V2beta1HorizontalPodAutoscaler",
     "V2beta1HorizontalPodAutoscalerList",
     "V2beta2HorizontalPodAutoscaler",
@@ -118,6 +120,10 @@ public class KubeSchema {
     private io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscaler v1HorizontalPodAutoscaler;
     @JsonProperty("V1HorizontalPodAutoscalerList")
     private io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerList v1HorizontalPodAutoscalerList;
+    @JsonProperty("V2HorizontalPodAutoscaler")
+    private io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler v2HorizontalPodAutoscaler;
+    @JsonProperty("V2HorizontalPodAutoscalerList")
+    private io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList v2HorizontalPodAutoscalerList;
     @JsonProperty("V2beta1HorizontalPodAutoscaler")
     private io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscaler v2beta1HorizontalPodAutoscaler;
     @JsonProperty("V2beta1HorizontalPodAutoscalerList")
@@ -156,6 +162,8 @@ public class KubeSchema {
      * @param v2beta1HorizontalPodAutoscalerList
      * @param v2beta2HorizontalPodAutoscaler
      * @param v2beta1HorizontalPodAutoscaler
+     * @param v2HorizontalPodAutoscaler
+     * @param v2HorizontalPodAutoscalerList
      * @param objectMeta
      * @param rootPaths
      * @param getOptions
@@ -163,7 +171,7 @@ public class KubeSchema {
      * @param info
      * @param status
      */
-    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, BaseKubernetesList baseKubernetesList, CreateOptions createOptions, DeleteOptions deleteOptions, GetOptions getOptions, Info info, ListOptions listOptions, io.fabric8.kubernetes.api.model.ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, Quantity quantity, RootPaths rootPaths, Scale scale, Status status, String time, TypeMeta typeMeta, UpdateOptions updateOptions, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscaler v1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerList v1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscaler v2beta1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscalerList v2beta1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscaler v2beta2HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList v2beta2HorizontalPodAutoscalerList) {
+    public KubeSchema(APIGroup aPIGroup, APIGroupList aPIGroupList, BaseKubernetesList baseKubernetesList, CreateOptions createOptions, DeleteOptions deleteOptions, GetOptions getOptions, Info info, ListOptions listOptions, io.fabric8.kubernetes.api.model.ObjectMeta objectMeta, Patch patch, PatchOptions patchOptions, Quantity quantity, RootPaths rootPaths, Scale scale, Status status, String time, TypeMeta typeMeta, UpdateOptions updateOptions, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscaler v1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerList v1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscaler v2beta1HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta1.HorizontalPodAutoscalerList v2beta1HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscaler v2beta2HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList v2beta2HorizontalPodAutoscalerList, io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler v2HorizontalPodAutoscaler, io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList v2HorizontalPodAutoscalerList) {
         super();
         this.aPIGroup = aPIGroup;
         this.aPIGroupList = aPIGroupList;
@@ -189,6 +197,8 @@ public class KubeSchema {
         this.v2beta1HorizontalPodAutoscalerList = v2beta1HorizontalPodAutoscalerList;
         this.v2beta2HorizontalPodAutoscaler = v2beta2HorizontalPodAutoscaler;
         this.v2beta2HorizontalPodAutoscalerList = v2beta2HorizontalPodAutoscalerList;
+        this.v2HorizontalPodAutoscaler = v2HorizontalPodAutoscaler;
+        this.v2HorizontalPodAutoscalerList = v2HorizontalPodAutoscalerList;
     }
 
     @JsonProperty("APIGroup")
@@ -421,6 +431,15 @@ public class KubeSchema {
         this.v2beta2HorizontalPodAutoscaler = v2beta2HorizontalPodAutoscaler;
     }
 
+  @JsonProperty("V2HorizontalPodAutoscaler")
+  public io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler getV2HorizontalPodAutoscaler() {
+    return v2HorizontalPodAutoscaler;
+  }
+
+  @JsonProperty("V2HorizontalPodAutoscaler")
+  public void setV2HorizontalPodAutoscaler(io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler v2HorizontalPodAutoscaler) {
+    this.v2HorizontalPodAutoscaler = v2HorizontalPodAutoscaler;
+  }
     @JsonProperty("V2beta2HorizontalPodAutoscalerList")
     public io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList getV2beta2HorizontalPodAutoscalerList() {
         return v2beta2HorizontalPodAutoscalerList;
@@ -429,6 +448,16 @@ public class KubeSchema {
     @JsonProperty("V2beta2HorizontalPodAutoscalerList")
     public void setV2beta2HorizontalPodAutoscalerList(io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerList v2beta2HorizontalPodAutoscalerList) {
         this.v2beta2HorizontalPodAutoscalerList = v2beta2HorizontalPodAutoscalerList;
+    }
+
+    @JsonProperty("V2HorizontalPodAutoscalerList")
+    public io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList getV2HorizontalPodAutoscalerList() {
+        return v2HorizontalPodAutoscalerList;
+    }
+
+    @JsonProperty("V2HorizontalPodAutoscalerList")
+    public void setV2HorizontalPodAutoscalerList(io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList v2HorizontalPodAutoscalerList) {
+        this.v2HorizontalPodAutoscalerList = v2HorizontalPodAutoscalerList;
     }
 
     @JsonAnyGetter

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ContainerResourceMetricSource.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ContainerResourceMetricSource.java
@@ -1,0 +1,130 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "container",
+    "name",
+    "target"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ContainerResourceMetricSource implements KubernetesResource
+{
+
+    @JsonProperty("container")
+    private String container;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("target")
+    private MetricTarget target;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ContainerResourceMetricSource() {
+    }
+
+    /**
+     * 
+     * @param container
+     * @param name
+     * @param target
+     */
+    public ContainerResourceMetricSource(String container, String name, MetricTarget target) {
+        super();
+        this.container = container;
+        this.name = name;
+        this.target = target;
+    }
+
+    @JsonProperty("container")
+    public String getContainer() {
+        return container;
+    }
+
+    @JsonProperty("container")
+    public void setContainer(String container) {
+        this.container = container;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("target")
+    public MetricTarget getTarget() {
+        return target;
+    }
+
+    @JsonProperty("target")
+    public void setTarget(MetricTarget target) {
+        this.target = target;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ContainerResourceMetricStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ContainerResourceMetricStatus.java
@@ -1,0 +1,130 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "container",
+    "current",
+    "name"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ContainerResourceMetricStatus implements KubernetesResource
+{
+
+    @JsonProperty("container")
+    private String container;
+    @JsonProperty("current")
+    private MetricValueStatus current;
+    @JsonProperty("name")
+    private String name;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ContainerResourceMetricStatus() {
+    }
+
+    /**
+     * 
+     * @param container
+     * @param current
+     * @param name
+     */
+    public ContainerResourceMetricStatus(String container, MetricValueStatus current, String name) {
+        super();
+        this.container = container;
+        this.current = current;
+        this.name = name;
+    }
+
+    @JsonProperty("container")
+    public String getContainer() {
+        return container;
+    }
+
+    @JsonProperty("container")
+    public void setContainer(String container) {
+        this.container = container;
+    }
+
+    @JsonProperty("current")
+    public MetricValueStatus getCurrent() {
+        return current;
+    }
+
+    @JsonProperty("current")
+    public void setCurrent(MetricValueStatus current) {
+        this.current = current;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/CrossVersionObjectReference.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/CrossVersionObjectReference.java
@@ -1,0 +1,128 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "name"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class CrossVersionObjectReference implements KubernetesResource
+{
+
+    @JsonProperty("apiVersion")
+    private String apiVersion;
+    @JsonProperty("kind")
+    private String kind;
+    @JsonProperty("name")
+    private String name;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public CrossVersionObjectReference() {
+    }
+
+    /**
+     * 
+     * @param apiVersion
+     * @param kind
+     * @param name
+     */
+    public CrossVersionObjectReference(String apiVersion, String kind, String name) {
+        super();
+        this.apiVersion = apiVersion;
+        this.kind = kind;
+        this.name = name;
+    }
+
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    @JsonProperty("apiVersion")
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ExternalMetricSource.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ExternalMetricSource.java
@@ -1,0 +1,115 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "metric",
+    "target"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ExternalMetricSource implements KubernetesResource
+{
+
+    @JsonProperty("metric")
+    private MetricIdentifier metric;
+    @JsonProperty("target")
+    private MetricTarget target;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ExternalMetricSource() {
+    }
+
+    /**
+     * 
+     * @param metric
+     * @param target
+     */
+    public ExternalMetricSource(MetricIdentifier metric, MetricTarget target) {
+        super();
+        this.metric = metric;
+        this.target = target;
+    }
+
+    @JsonProperty("metric")
+    public MetricIdentifier getMetric() {
+        return metric;
+    }
+
+    @JsonProperty("metric")
+    public void setMetric(MetricIdentifier metric) {
+        this.metric = metric;
+    }
+
+    @JsonProperty("target")
+    public MetricTarget getTarget() {
+        return target;
+    }
+
+    @JsonProperty("target")
+    public void setTarget(MetricTarget target) {
+        this.target = target;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ExternalMetricStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ExternalMetricStatus.java
@@ -1,0 +1,115 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "current",
+    "metric"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ExternalMetricStatus implements KubernetesResource
+{
+
+    @JsonProperty("current")
+    private MetricValueStatus current;
+    @JsonProperty("metric")
+    private MetricIdentifier metric;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ExternalMetricStatus() {
+    }
+
+    /**
+     * 
+     * @param current
+     * @param metric
+     */
+    public ExternalMetricStatus(MetricValueStatus current, MetricIdentifier metric) {
+        super();
+        this.current = current;
+        this.metric = metric;
+    }
+
+    @JsonProperty("current")
+    public MetricValueStatus getCurrent() {
+        return current;
+    }
+
+    @JsonProperty("current")
+    public void setCurrent(MetricValueStatus current) {
+        this.current = current;
+    }
+
+    @JsonProperty("metric")
+    public MetricIdentifier getMetric() {
+        return metric;
+    }
+
+    @JsonProperty("metric")
+    public void setMetric(MetricIdentifier metric) {
+        this.metric = metric;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HPAScalingPolicy.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HPAScalingPolicy.java
@@ -1,0 +1,130 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "periodSeconds",
+    "type",
+    "value"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class HPAScalingPolicy implements KubernetesResource
+{
+
+    @JsonProperty("periodSeconds")
+    private Integer periodSeconds;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("value")
+    private Integer value;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HPAScalingPolicy() {
+    }
+
+    /**
+     * 
+     * @param periodSeconds
+     * @param type
+     * @param value
+     */
+    public HPAScalingPolicy(Integer periodSeconds, String type, Integer value) {
+        super();
+        this.periodSeconds = periodSeconds;
+        this.type = type;
+        this.value = value;
+    }
+
+    @JsonProperty("periodSeconds")
+    public Integer getPeriodSeconds() {
+        return periodSeconds;
+    }
+
+    @JsonProperty("periodSeconds")
+    public void setPeriodSeconds(Integer periodSeconds) {
+        this.periodSeconds = periodSeconds;
+    }
+
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @JsonProperty("value")
+    public Integer getValue() {
+        return value;
+    }
+
+    @JsonProperty("value")
+    public void setValue(Integer value) {
+        this.value = value;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HPAScalingRules.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HPAScalingRules.java
@@ -1,0 +1,133 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "policies",
+    "selectPolicy",
+    "stabilizationWindowSeconds"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class HPAScalingRules implements KubernetesResource
+{
+
+    @JsonProperty("policies")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<HPAScalingPolicy> policies = new ArrayList<HPAScalingPolicy>();
+    @JsonProperty("selectPolicy")
+    private String selectPolicy;
+    @JsonProperty("stabilizationWindowSeconds")
+    private Integer stabilizationWindowSeconds;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HPAScalingRules() {
+    }
+
+    /**
+     * 
+     * @param selectPolicy
+     * @param stabilizationWindowSeconds
+     * @param policies
+     */
+    public HPAScalingRules(List<HPAScalingPolicy> policies, String selectPolicy, Integer stabilizationWindowSeconds) {
+        super();
+        this.policies = policies;
+        this.selectPolicy = selectPolicy;
+        this.stabilizationWindowSeconds = stabilizationWindowSeconds;
+    }
+
+    @JsonProperty("policies")
+    public List<HPAScalingPolicy> getPolicies() {
+        return policies;
+    }
+
+    @JsonProperty("policies")
+    public void setPolicies(List<HPAScalingPolicy> policies) {
+        this.policies = policies;
+    }
+
+    @JsonProperty("selectPolicy")
+    public String getSelectPolicy() {
+        return selectPolicy;
+    }
+
+    @JsonProperty("selectPolicy")
+    public void setSelectPolicy(String selectPolicy) {
+        this.selectPolicy = selectPolicy;
+    }
+
+    @JsonProperty("stabilizationWindowSeconds")
+    public Integer getStabilizationWindowSeconds() {
+        return stabilizationWindowSeconds;
+    }
+
+    @JsonProperty("stabilizationWindowSeconds")
+    public void setStabilizationWindowSeconds(Integer stabilizationWindowSeconds) {
+        this.stabilizationWindowSeconds = stabilizationWindowSeconds;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscaler.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscaler.java
@@ -1,0 +1,196 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import io.sundr.transform.annotations.TemplateTransformation;
+import io.sundr.transform.annotations.TemplateTransformations;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "spec",
+    "status"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(io.fabric8.kubernetes.api.model.ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+@Version("v2")
+@Group("autoscaling")
+@TemplateTransformations({
+    @TemplateTransformation(value = "/manifest.vm", outputPath = "autoscaling.properties", gather = true)
+})
+public class HorizontalPodAutoscaler implements HasMetadata, Namespaced
+{
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    private String apiVersion = "autoscaling/v2";
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    private String kind = "HorizontalPodAutoscaler";
+    @JsonProperty("metadata")
+    private io.fabric8.kubernetes.api.model.ObjectMeta metadata;
+    @JsonProperty("spec")
+    private HorizontalPodAutoscalerSpec spec;
+    @JsonProperty("status")
+    private HorizontalPodAutoscalerStatus status;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HorizontalPodAutoscaler() {
+    }
+
+    /**
+     * 
+     * @param metadata
+     * @param apiVersion
+     * @param kind
+     * @param spec
+     * @param status
+     */
+    public HorizontalPodAutoscaler(String apiVersion, String kind, io.fabric8.kubernetes.api.model.ObjectMeta metadata, HorizontalPodAutoscalerSpec spec, HorizontalPodAutoscalerStatus status) {
+        super();
+        this.apiVersion = apiVersion;
+        this.kind = kind;
+        this.metadata = metadata;
+        this.spec = spec;
+        this.status = status;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("metadata")
+    public io.fabric8.kubernetes.api.model.ObjectMeta getMetadata() {
+        return metadata;
+    }
+
+    @JsonProperty("metadata")
+    public void setMetadata(io.fabric8.kubernetes.api.model.ObjectMeta metadata) {
+        this.metadata = metadata;
+    }
+
+    @JsonProperty("spec")
+    public HorizontalPodAutoscalerSpec getSpec() {
+        return spec;
+    }
+
+    @JsonProperty("spec")
+    public void setSpec(HorizontalPodAutoscalerSpec spec) {
+        this.spec = spec;
+    }
+
+    @JsonProperty("status")
+    public HorizontalPodAutoscalerStatus getStatus() {
+        return status;
+    }
+
+    @JsonProperty("status")
+    public void setStatus(HorizontalPodAutoscalerStatus status) {
+        this.status = status;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerBehavior.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerBehavior.java
@@ -1,0 +1,115 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "scaleDown",
+    "scaleUp"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class HorizontalPodAutoscalerBehavior implements KubernetesResource
+{
+
+    @JsonProperty("scaleDown")
+    private HPAScalingRules scaleDown;
+    @JsonProperty("scaleUp")
+    private HPAScalingRules scaleUp;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HorizontalPodAutoscalerBehavior() {
+    }
+
+    /**
+     * 
+     * @param scaleUp
+     * @param scaleDown
+     */
+    public HorizontalPodAutoscalerBehavior(HPAScalingRules scaleDown, HPAScalingRules scaleUp) {
+        super();
+        this.scaleDown = scaleDown;
+        this.scaleUp = scaleUp;
+    }
+
+    @JsonProperty("scaleDown")
+    public HPAScalingRules getScaleDown() {
+        return scaleDown;
+    }
+
+    @JsonProperty("scaleDown")
+    public void setScaleDown(HPAScalingRules scaleDown) {
+        this.scaleDown = scaleDown;
+    }
+
+    @JsonProperty("scaleUp")
+    public HPAScalingRules getScaleUp() {
+        return scaleUp;
+    }
+
+    @JsonProperty("scaleUp")
+    public void setScaleUp(HPAScalingRules scaleUp) {
+        this.scaleUp = scaleUp;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerCondition.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerCondition.java
@@ -1,0 +1,160 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "lastTransitionTime",
+    "message",
+    "reason",
+    "status",
+    "type"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class HorizontalPodAutoscalerCondition implements KubernetesResource
+{
+
+    @JsonProperty("lastTransitionTime")
+    private String lastTransitionTime;
+    @JsonProperty("message")
+    private java.lang.String message;
+    @JsonProperty("reason")
+    private java.lang.String reason;
+    @JsonProperty("status")
+    private java.lang.String status;
+    @JsonProperty("type")
+    private java.lang.String type;
+    @JsonIgnore
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HorizontalPodAutoscalerCondition() {
+    }
+
+    /**
+     * 
+     * @param reason
+     * @param lastTransitionTime
+     * @param message
+     * @param type
+     * @param status
+     */
+    public HorizontalPodAutoscalerCondition(String lastTransitionTime, java.lang.String message, java.lang.String reason, java.lang.String status, java.lang.String type) {
+        super();
+        this.lastTransitionTime = lastTransitionTime;
+        this.message = message;
+        this.reason = reason;
+        this.status = status;
+        this.type = type;
+    }
+
+    @JsonProperty("lastTransitionTime")
+    public String getLastTransitionTime() {
+        return lastTransitionTime;
+    }
+
+    @JsonProperty("lastTransitionTime")
+    public void setLastTransitionTime(String lastTransitionTime) {
+        this.lastTransitionTime = lastTransitionTime;
+    }
+
+    @JsonProperty("message")
+    public java.lang.String getMessage() {
+        return message;
+    }
+
+    @JsonProperty("message")
+    public void setMessage(java.lang.String message) {
+        this.message = message;
+    }
+
+    @JsonProperty("reason")
+    public java.lang.String getReason() {
+        return reason;
+    }
+
+    @JsonProperty("reason")
+    public void setReason(java.lang.String reason) {
+        this.reason = reason;
+    }
+
+    @JsonProperty("status")
+    public java.lang.String getStatus() {
+        return status;
+    }
+
+    @JsonProperty("status")
+    public void setStatus(java.lang.String status) {
+        this.status = status;
+    }
+
+    @JsonProperty("type")
+    public java.lang.String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(java.lang.String type) {
+        this.type = type;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerList.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerList.java
@@ -1,0 +1,180 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.KubernetesResourceList;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.ListMeta;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.Version;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "items"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+@Version("v2")
+@Group("autoscaling")
+public class HorizontalPodAutoscalerList implements KubernetesResource, KubernetesResourceList<io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler>
+{
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    private String apiVersion = "autoscaling/v2";
+    @JsonProperty("items")
+    private List<io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler> items = new ArrayList<io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler>();
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    private String kind = "HorizontalPodAutoscalerList";
+    @JsonProperty("metadata")
+    private ListMeta metadata;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HorizontalPodAutoscalerList() {
+    }
+
+    /**
+     * 
+     * @param metadata
+     * @param apiVersion
+     * @param kind
+     * @param items
+     */
+    public HorizontalPodAutoscalerList(String apiVersion, List<io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler> items, String kind, ListMeta metadata) {
+        super();
+        this.apiVersion = apiVersion;
+        this.items = items;
+        this.kind = kind;
+        this.metadata = metadata;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public String getApiVersion() {
+        return apiVersion;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("apiVersion")
+    public void setApiVersion(String apiVersion) {
+        this.apiVersion = apiVersion;
+    }
+
+    @JsonProperty("items")
+    public List<io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler> getItems() {
+        return items;
+    }
+
+    @JsonProperty("items")
+    public void setItems(List<io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler> items) {
+        this.items = items;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public String getKind() {
+        return kind;
+    }
+
+    /**
+     * 
+     * (Required)
+     * 
+     */
+    @JsonProperty("kind")
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+
+    @JsonProperty("metadata")
+    public ListMeta getMetadata() {
+        return metadata;
+    }
+
+    @JsonProperty("metadata")
+    public void setMetadata(ListMeta metadata) {
+        this.metadata = metadata;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerSpec.java
@@ -1,0 +1,163 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "behavior",
+    "maxReplicas",
+    "metrics",
+    "minReplicas",
+    "scaleTargetRef"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class HorizontalPodAutoscalerSpec implements KubernetesResource
+{
+
+    @JsonProperty("behavior")
+    private HorizontalPodAutoscalerBehavior behavior;
+    @JsonProperty("maxReplicas")
+    private Integer maxReplicas;
+    @JsonProperty("metrics")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<MetricSpec> metrics = new ArrayList<MetricSpec>();
+    @JsonProperty("minReplicas")
+    private Integer minReplicas;
+    @JsonProperty("scaleTargetRef")
+    private CrossVersionObjectReference scaleTargetRef;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HorizontalPodAutoscalerSpec() {
+    }
+
+    /**
+     * 
+     * @param maxReplicas
+     * @param minReplicas
+     * @param metrics
+     * @param behavior
+     * @param scaleTargetRef
+     */
+    public HorizontalPodAutoscalerSpec(HorizontalPodAutoscalerBehavior behavior, Integer maxReplicas, List<MetricSpec> metrics, Integer minReplicas, CrossVersionObjectReference scaleTargetRef) {
+        super();
+        this.behavior = behavior;
+        this.maxReplicas = maxReplicas;
+        this.metrics = metrics;
+        this.minReplicas = minReplicas;
+        this.scaleTargetRef = scaleTargetRef;
+    }
+
+    @JsonProperty("behavior")
+    public HorizontalPodAutoscalerBehavior getBehavior() {
+        return behavior;
+    }
+
+    @JsonProperty("behavior")
+    public void setBehavior(HorizontalPodAutoscalerBehavior behavior) {
+        this.behavior = behavior;
+    }
+
+    @JsonProperty("maxReplicas")
+    public Integer getMaxReplicas() {
+        return maxReplicas;
+    }
+
+    @JsonProperty("maxReplicas")
+    public void setMaxReplicas(Integer maxReplicas) {
+        this.maxReplicas = maxReplicas;
+    }
+
+    @JsonProperty("metrics")
+    public List<MetricSpec> getMetrics() {
+        return metrics;
+    }
+
+    @JsonProperty("metrics")
+    public void setMetrics(List<MetricSpec> metrics) {
+        this.metrics = metrics;
+    }
+
+    @JsonProperty("minReplicas")
+    public Integer getMinReplicas() {
+        return minReplicas;
+    }
+
+    @JsonProperty("minReplicas")
+    public void setMinReplicas(Integer minReplicas) {
+        this.minReplicas = minReplicas;
+    }
+
+    @JsonProperty("scaleTargetRef")
+    public CrossVersionObjectReference getScaleTargetRef() {
+        return scaleTargetRef;
+    }
+
+    @JsonProperty("scaleTargetRef")
+    public void setScaleTargetRef(CrossVersionObjectReference scaleTargetRef) {
+        this.scaleTargetRef = scaleTargetRef;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/HorizontalPodAutoscalerStatus.java
@@ -1,0 +1,178 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "conditions",
+    "currentMetrics",
+    "currentReplicas",
+    "desiredReplicas",
+    "lastScaleTime",
+    "observedGeneration"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class HorizontalPodAutoscalerStatus implements KubernetesResource
+{
+
+    @JsonProperty("conditions")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private List<HorizontalPodAutoscalerCondition> conditions = new ArrayList<HorizontalPodAutoscalerCondition>();
+    @JsonProperty("currentMetrics")
+    private List<MetricStatus> currentMetrics = new ArrayList<MetricStatus>();
+    @JsonProperty("currentReplicas")
+    private Integer currentReplicas;
+    @JsonProperty("desiredReplicas")
+    private Integer desiredReplicas;
+    @JsonProperty("lastScaleTime")
+    private String lastScaleTime;
+    @JsonProperty("observedGeneration")
+    private Long observedGeneration;
+    @JsonIgnore
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public HorizontalPodAutoscalerStatus() {
+    }
+
+    /**
+     * 
+     * @param desiredReplicas
+     * @param currentReplicas
+     * @param conditions
+     * @param lastScaleTime
+     * @param observedGeneration
+     * @param currentMetrics
+     */
+    public HorizontalPodAutoscalerStatus(List<HorizontalPodAutoscalerCondition> conditions, List<MetricStatus> currentMetrics, Integer currentReplicas, Integer desiredReplicas, String lastScaleTime, Long observedGeneration) {
+        super();
+        this.conditions = conditions;
+        this.currentMetrics = currentMetrics;
+        this.currentReplicas = currentReplicas;
+        this.desiredReplicas = desiredReplicas;
+        this.lastScaleTime = lastScaleTime;
+        this.observedGeneration = observedGeneration;
+    }
+
+    @JsonProperty("conditions")
+    public List<HorizontalPodAutoscalerCondition> getConditions() {
+        return conditions;
+    }
+
+    @JsonProperty("conditions")
+    public void setConditions(List<HorizontalPodAutoscalerCondition> conditions) {
+        this.conditions = conditions;
+    }
+
+    @JsonProperty("currentMetrics")
+    public List<MetricStatus> getCurrentMetrics() {
+        return currentMetrics;
+    }
+
+    @JsonProperty("currentMetrics")
+    public void setCurrentMetrics(List<MetricStatus> currentMetrics) {
+        this.currentMetrics = currentMetrics;
+    }
+
+    @JsonProperty("currentReplicas")
+    public Integer getCurrentReplicas() {
+        return currentReplicas;
+    }
+
+    @JsonProperty("currentReplicas")
+    public void setCurrentReplicas(Integer currentReplicas) {
+        this.currentReplicas = currentReplicas;
+    }
+
+    @JsonProperty("desiredReplicas")
+    public Integer getDesiredReplicas() {
+        return desiredReplicas;
+    }
+
+    @JsonProperty("desiredReplicas")
+    public void setDesiredReplicas(Integer desiredReplicas) {
+        this.desiredReplicas = desiredReplicas;
+    }
+
+    @JsonProperty("lastScaleTime")
+    public String getLastScaleTime() {
+        return lastScaleTime;
+    }
+
+    @JsonProperty("lastScaleTime")
+    public void setLastScaleTime(String lastScaleTime) {
+        this.lastScaleTime = lastScaleTime;
+    }
+
+    @JsonProperty("observedGeneration")
+    public Long getObservedGeneration() {
+        return observedGeneration;
+    }
+
+    @JsonProperty("observedGeneration")
+    public void setObservedGeneration(Long observedGeneration) {
+        this.observedGeneration = observedGeneration;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricIdentifier.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricIdentifier.java
@@ -1,0 +1,114 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "name",
+    "selector"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(io.fabric8.kubernetes.api.model.LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class MetricIdentifier implements KubernetesResource
+{
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("selector")
+    private io.fabric8.kubernetes.api.model.LabelSelector selector;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public MetricIdentifier() {
+    }
+
+    /**
+     * 
+     * @param name
+     * @param selector
+     */
+    public MetricIdentifier(String name, io.fabric8.kubernetes.api.model.LabelSelector selector) {
+        super();
+        this.name = name;
+        this.selector = selector;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("selector")
+    public io.fabric8.kubernetes.api.model.LabelSelector getSelector() {
+        return selector;
+    }
+
+    @JsonProperty("selector")
+    public void setSelector(io.fabric8.kubernetes.api.model.LabelSelector selector) {
+        this.selector = selector;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricSpec.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricSpec.java
@@ -1,0 +1,175 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "containerResource",
+    "external",
+    "object",
+    "pods",
+    "resource",
+    "type"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class MetricSpec implements KubernetesResource
+{
+
+    @JsonProperty("containerResource")
+    private ContainerResourceMetricSource containerResource;
+    @JsonProperty("external")
+    private ExternalMetricSource external;
+    @JsonProperty("object")
+    private ObjectMetricSource object;
+    @JsonProperty("pods")
+    private PodsMetricSource pods;
+    @JsonProperty("resource")
+    private ResourceMetricSource resource;
+    @JsonProperty("type")
+    private String type;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public MetricSpec() {
+    }
+
+    /**
+     * 
+     * @param external
+     * @param resource
+     * @param containerResource
+     * @param pods
+     * @param type
+     * @param object
+     */
+    public MetricSpec(ContainerResourceMetricSource containerResource, ExternalMetricSource external, ObjectMetricSource object, PodsMetricSource pods, ResourceMetricSource resource, String type) {
+        super();
+        this.containerResource = containerResource;
+        this.external = external;
+        this.object = object;
+        this.pods = pods;
+        this.resource = resource;
+        this.type = type;
+    }
+
+    @JsonProperty("containerResource")
+    public ContainerResourceMetricSource getContainerResource() {
+        return containerResource;
+    }
+
+    @JsonProperty("containerResource")
+    public void setContainerResource(ContainerResourceMetricSource containerResource) {
+        this.containerResource = containerResource;
+    }
+
+    @JsonProperty("external")
+    public ExternalMetricSource getExternal() {
+        return external;
+    }
+
+    @JsonProperty("external")
+    public void setExternal(ExternalMetricSource external) {
+        this.external = external;
+    }
+
+    @JsonProperty("object")
+    public ObjectMetricSource getObject() {
+        return object;
+    }
+
+    @JsonProperty("object")
+    public void setObject(ObjectMetricSource object) {
+        this.object = object;
+    }
+
+    @JsonProperty("pods")
+    public PodsMetricSource getPods() {
+        return pods;
+    }
+
+    @JsonProperty("pods")
+    public void setPods(PodsMetricSource pods) {
+        this.pods = pods;
+    }
+
+    @JsonProperty("resource")
+    public ResourceMetricSource getResource() {
+        return resource;
+    }
+
+    @JsonProperty("resource")
+    public void setResource(ResourceMetricSource resource) {
+        this.resource = resource;
+    }
+
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricStatus.java
@@ -1,0 +1,175 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "containerResource",
+    "external",
+    "object",
+    "pods",
+    "resource",
+    "type"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class MetricStatus implements KubernetesResource
+{
+
+    @JsonProperty("containerResource")
+    private ContainerResourceMetricStatus containerResource;
+    @JsonProperty("external")
+    private ExternalMetricStatus external;
+    @JsonProperty("object")
+    private ObjectMetricStatus object;
+    @JsonProperty("pods")
+    private PodsMetricStatus pods;
+    @JsonProperty("resource")
+    private ResourceMetricStatus resource;
+    @JsonProperty("type")
+    private String type;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public MetricStatus() {
+    }
+
+    /**
+     * 
+     * @param external
+     * @param resource
+     * @param containerResource
+     * @param pods
+     * @param type
+     * @param object
+     */
+    public MetricStatus(ContainerResourceMetricStatus containerResource, ExternalMetricStatus external, ObjectMetricStatus object, PodsMetricStatus pods, ResourceMetricStatus resource, String type) {
+        super();
+        this.containerResource = containerResource;
+        this.external = external;
+        this.object = object;
+        this.pods = pods;
+        this.resource = resource;
+        this.type = type;
+    }
+
+    @JsonProperty("containerResource")
+    public ContainerResourceMetricStatus getContainerResource() {
+        return containerResource;
+    }
+
+    @JsonProperty("containerResource")
+    public void setContainerResource(ContainerResourceMetricStatus containerResource) {
+        this.containerResource = containerResource;
+    }
+
+    @JsonProperty("external")
+    public ExternalMetricStatus getExternal() {
+        return external;
+    }
+
+    @JsonProperty("external")
+    public void setExternal(ExternalMetricStatus external) {
+        this.external = external;
+    }
+
+    @JsonProperty("object")
+    public ObjectMetricStatus getObject() {
+        return object;
+    }
+
+    @JsonProperty("object")
+    public void setObject(ObjectMetricStatus object) {
+        this.object = object;
+    }
+
+    @JsonProperty("pods")
+    public PodsMetricStatus getPods() {
+        return pods;
+    }
+
+    @JsonProperty("pods")
+    public void setPods(PodsMetricStatus pods) {
+        this.pods = pods;
+    }
+
+    @JsonProperty("resource")
+    public ResourceMetricStatus getResource() {
+        return resource;
+    }
+
+    @JsonProperty("resource")
+    public void setResource(ResourceMetricStatus resource) {
+        this.resource = resource;
+    }
+
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricTarget.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricTarget.java
@@ -1,0 +1,146 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "averageUtilization",
+    "averageValue",
+    "type",
+    "value"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class MetricTarget implements KubernetesResource
+{
+
+    @JsonProperty("averageUtilization")
+    private Integer averageUtilization;
+    @JsonProperty("averageValue")
+    private Quantity averageValue;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("value")
+    private Quantity value;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public MetricTarget() {
+    }
+
+    /**
+     * 
+     * @param averageValue
+     * @param averageUtilization
+     * @param type
+     * @param value
+     */
+    public MetricTarget(Integer averageUtilization, Quantity averageValue, String type, Quantity value) {
+        super();
+        this.averageUtilization = averageUtilization;
+        this.averageValue = averageValue;
+        this.type = type;
+        this.value = value;
+    }
+
+    @JsonProperty("averageUtilization")
+    public Integer getAverageUtilization() {
+        return averageUtilization;
+    }
+
+    @JsonProperty("averageUtilization")
+    public void setAverageUtilization(Integer averageUtilization) {
+        this.averageUtilization = averageUtilization;
+    }
+
+    @JsonProperty("averageValue")
+    public Quantity getAverageValue() {
+        return averageValue;
+    }
+
+    @JsonProperty("averageValue")
+    public void setAverageValue(Quantity averageValue) {
+        this.averageValue = averageValue;
+    }
+
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @JsonProperty("value")
+    public Quantity getValue() {
+        return value;
+    }
+
+    @JsonProperty("value")
+    public void setValue(Quantity value) {
+        this.value = value;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricValueStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/MetricValueStatus.java
@@ -1,0 +1,131 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "averageUtilization",
+    "averageValue",
+    "value"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class MetricValueStatus implements KubernetesResource
+{
+
+    @JsonProperty("averageUtilization")
+    private Integer averageUtilization;
+    @JsonProperty("averageValue")
+    private Quantity averageValue;
+    @JsonProperty("value")
+    private Quantity value;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public MetricValueStatus() {
+    }
+
+    /**
+     * 
+     * @param averageValue
+     * @param averageUtilization
+     * @param value
+     */
+    public MetricValueStatus(Integer averageUtilization, Quantity averageValue, Quantity value) {
+        super();
+        this.averageUtilization = averageUtilization;
+        this.averageValue = averageValue;
+        this.value = value;
+    }
+
+    @JsonProperty("averageUtilization")
+    public Integer getAverageUtilization() {
+        return averageUtilization;
+    }
+
+    @JsonProperty("averageUtilization")
+    public void setAverageUtilization(Integer averageUtilization) {
+        this.averageUtilization = averageUtilization;
+    }
+
+    @JsonProperty("averageValue")
+    public Quantity getAverageValue() {
+        return averageValue;
+    }
+
+    @JsonProperty("averageValue")
+    public void setAverageValue(Quantity averageValue) {
+        this.averageValue = averageValue;
+    }
+
+    @JsonProperty("value")
+    public Quantity getValue() {
+        return value;
+    }
+
+    @JsonProperty("value")
+    public void setValue(Quantity value) {
+        this.value = value;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ObjectMetricSource.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ObjectMetricSource.java
@@ -1,0 +1,130 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "describedObject",
+    "metric",
+    "target"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ObjectMetricSource implements KubernetesResource
+{
+
+    @JsonProperty("describedObject")
+    private CrossVersionObjectReference describedObject;
+    @JsonProperty("metric")
+    private MetricIdentifier metric;
+    @JsonProperty("target")
+    private MetricTarget target;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ObjectMetricSource() {
+    }
+
+    /**
+     * 
+     * @param describedObject
+     * @param metric
+     * @param target
+     */
+    public ObjectMetricSource(CrossVersionObjectReference describedObject, MetricIdentifier metric, MetricTarget target) {
+        super();
+        this.describedObject = describedObject;
+        this.metric = metric;
+        this.target = target;
+    }
+
+    @JsonProperty("describedObject")
+    public CrossVersionObjectReference getDescribedObject() {
+        return describedObject;
+    }
+
+    @JsonProperty("describedObject")
+    public void setDescribedObject(CrossVersionObjectReference describedObject) {
+        this.describedObject = describedObject;
+    }
+
+    @JsonProperty("metric")
+    public MetricIdentifier getMetric() {
+        return metric;
+    }
+
+    @JsonProperty("metric")
+    public void setMetric(MetricIdentifier metric) {
+        this.metric = metric;
+    }
+
+    @JsonProperty("target")
+    public MetricTarget getTarget() {
+        return target;
+    }
+
+    @JsonProperty("target")
+    public void setTarget(MetricTarget target) {
+        this.target = target;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ObjectMetricStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ObjectMetricStatus.java
@@ -1,0 +1,130 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "current",
+    "describedObject",
+    "metric"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ObjectMetricStatus implements KubernetesResource
+{
+
+    @JsonProperty("current")
+    private MetricValueStatus current;
+    @JsonProperty("describedObject")
+    private CrossVersionObjectReference describedObject;
+    @JsonProperty("metric")
+    private MetricIdentifier metric;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ObjectMetricStatus() {
+    }
+
+    /**
+     * 
+     * @param describedObject
+     * @param current
+     * @param metric
+     */
+    public ObjectMetricStatus(MetricValueStatus current, CrossVersionObjectReference describedObject, MetricIdentifier metric) {
+        super();
+        this.current = current;
+        this.describedObject = describedObject;
+        this.metric = metric;
+    }
+
+    @JsonProperty("current")
+    public MetricValueStatus getCurrent() {
+        return current;
+    }
+
+    @JsonProperty("current")
+    public void setCurrent(MetricValueStatus current) {
+        this.current = current;
+    }
+
+    @JsonProperty("describedObject")
+    public CrossVersionObjectReference getDescribedObject() {
+        return describedObject;
+    }
+
+    @JsonProperty("describedObject")
+    public void setDescribedObject(CrossVersionObjectReference describedObject) {
+        this.describedObject = describedObject;
+    }
+
+    @JsonProperty("metric")
+    public MetricIdentifier getMetric() {
+        return metric;
+    }
+
+    @JsonProperty("metric")
+    public void setMetric(MetricIdentifier metric) {
+        this.metric = metric;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/PodsMetricSource.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/PodsMetricSource.java
@@ -1,0 +1,115 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "metric",
+    "target"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class PodsMetricSource implements KubernetesResource
+{
+
+    @JsonProperty("metric")
+    private MetricIdentifier metric;
+    @JsonProperty("target")
+    private MetricTarget target;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public PodsMetricSource() {
+    }
+
+    /**
+     * 
+     * @param metric
+     * @param target
+     */
+    public PodsMetricSource(MetricIdentifier metric, MetricTarget target) {
+        super();
+        this.metric = metric;
+        this.target = target;
+    }
+
+    @JsonProperty("metric")
+    public MetricIdentifier getMetric() {
+        return metric;
+    }
+
+    @JsonProperty("metric")
+    public void setMetric(MetricIdentifier metric) {
+        this.metric = metric;
+    }
+
+    @JsonProperty("target")
+    public MetricTarget getTarget() {
+        return target;
+    }
+
+    @JsonProperty("target")
+    public void setTarget(MetricTarget target) {
+        this.target = target;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/PodsMetricStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/PodsMetricStatus.java
@@ -1,0 +1,115 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "current",
+    "metric"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class PodsMetricStatus implements KubernetesResource
+{
+
+    @JsonProperty("current")
+    private MetricValueStatus current;
+    @JsonProperty("metric")
+    private MetricIdentifier metric;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public PodsMetricStatus() {
+    }
+
+    /**
+     * 
+     * @param current
+     * @param metric
+     */
+    public PodsMetricStatus(MetricValueStatus current, MetricIdentifier metric) {
+        super();
+        this.current = current;
+        this.metric = metric;
+    }
+
+    @JsonProperty("current")
+    public MetricValueStatus getCurrent() {
+        return current;
+    }
+
+    @JsonProperty("current")
+    public void setCurrent(MetricValueStatus current) {
+        this.current = current;
+    }
+
+    @JsonProperty("metric")
+    public MetricIdentifier getMetric() {
+        return metric;
+    }
+
+    @JsonProperty("metric")
+    public void setMetric(MetricIdentifier metric) {
+        this.metric = metric;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ResourceMetricSource.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ResourceMetricSource.java
@@ -1,0 +1,115 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "name",
+    "target"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ResourceMetricSource implements KubernetesResource
+{
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("target")
+    private MetricTarget target;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ResourceMetricSource() {
+    }
+
+    /**
+     * 
+     * @param name
+     * @param target
+     */
+    public ResourceMetricSource(String name, MetricTarget target) {
+        super();
+        this.name = name;
+        this.target = target;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonProperty("target")
+    public MetricTarget getTarget() {
+        return target;
+    }
+
+    @JsonProperty("target")
+    public void setTarget(MetricTarget target) {
+        this.target = target;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ResourceMetricStatus.java
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/generated/java/io/fabric8/kubernetes/api/model/autoscaling/v2/ResourceMetricStatus.java
@@ -1,0 +1,115 @@
+
+package io.fabric8.kubernetes.api.model.autoscaling.v2;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.KubernetesResource;
+import io.fabric8.kubernetes.api.model.LabelSelector;
+import io.fabric8.kubernetes.api.model.LocalObjectReference;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectReference;
+import io.fabric8.kubernetes.api.model.PersistentVolumeClaim;
+import io.fabric8.kubernetes.api.model.PodTemplateSpec;
+import io.fabric8.kubernetes.api.model.ResourceRequirements;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+import lombok.EqualsAndHashCode;
+import lombok.Setter;
+import lombok.ToString;
+import lombok.experimental.Accessors;
+
+@JsonDeserialize(using = com.fasterxml.jackson.databind.JsonDeserializer.None.class)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "apiVersion",
+    "kind",
+    "metadata",
+    "current",
+    "name"
+})
+@ToString
+@EqualsAndHashCode
+@Setter
+@Accessors(prefix = {
+    "_",
+    ""
+})
+@Buildable(editableEnabled = false, validationEnabled = false, generateBuilderPackage = false, lazyCollectionInitEnabled = false, builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(ObjectMeta.class),
+    @BuildableReference(LabelSelector.class),
+    @BuildableReference(Container.class),
+    @BuildableReference(PodTemplateSpec.class),
+    @BuildableReference(ResourceRequirements.class),
+    @BuildableReference(IntOrString.class),
+    @BuildableReference(ObjectReference.class),
+    @BuildableReference(LocalObjectReference.class),
+    @BuildableReference(PersistentVolumeClaim.class)
+})
+public class ResourceMetricStatus implements KubernetesResource
+{
+
+    @JsonProperty("current")
+    private MetricValueStatus current;
+    @JsonProperty("name")
+    private String name;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * No args constructor for use in serialization
+     * 
+     */
+    public ResourceMetricStatus() {
+    }
+
+    /**
+     * 
+     * @param current
+     * @param name
+     */
+    public ResourceMetricStatus(MetricValueStatus current, String name) {
+        super();
+        this.current = current;
+        this.name = name;
+    }
+
+    @JsonProperty("current")
+    public MetricValueStatus getCurrent() {
+        return current;
+    }
+
+    @JsonProperty("current")
+    public void setCurrent(MetricValueStatus current) {
+        this.current = current;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/kube-schema.json
@@ -253,7 +253,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource"
+            "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata"
           }
         },
         "kind": {
@@ -267,10 +267,10 @@
         }
       },
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource",
-        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.KubernetesResource\u003e"
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.HasMetadata\u003e"
       ]
     },
     "kubernetes_apimachinery_ListMeta": {
@@ -387,6 +387,9 @@
             "type": "string"
           },
           "existingJavaType": "java.util.Map\u003cString, String\u003e"
+        },
+        "clusterName": {
+          "type": "string"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -735,10 +738,18 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_pkg_runtime_ImageRawExtension": {
+      "type": "object",
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.runtime.RawExtension",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_pkg_runtime_RawExtension": {
       "type": "object",
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -2599,7 +2610,7 @@
     },
     "BaseKubernetesList": {
       "$ref": "#/definitions/kubernetes_apimachinery_List",
-      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList"
+      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList"
     },
     "CreateOptions": {
       "$ref": "#/definitions/kubernetes_apimachinery_CreateOptions",

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/kube-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/kube-schema.json
@@ -253,7 +253,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata"
+            "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource"
           }
         },
         "kind": {
@@ -267,10 +267,10 @@
         }
       },
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource",
-        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.HasMetadata\u003e"
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.KubernetesResource\u003e"
       ]
     },
     "kubernetes_apimachinery_ListMeta": {
@@ -387,9 +387,6 @@
             "type": "string"
           },
           "existingJavaType": "java.util.Map\u003cString, String\u003e"
-        },
-        "clusterName": {
-          "type": "string"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -738,18 +735,10 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
-    "kubernetes_apimachinery_pkg_runtime_ImageRawExtension": {
-      "type": "object",
-      "additionalProperties": true,
-      "javaType": "io.fabric8.kubernetes.api.model.runtime.RawExtension",
-      "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.KubernetesResource"
-      ]
-    },
     "kubernetes_apimachinery_pkg_runtime_RawExtension": {
       "type": "object",
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -983,6 +972,566 @@
       },
       "additionalProperties": true,
       "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.ScaleStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ContainerResourceMetricSource": {
+      "type": "object",
+      "properties": {
+        "container": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ContainerResourceMetricStatus": {
+      "type": "object",
+      "properties": {
+        "container": {
+          "type": "string"
+        },
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_CrossVersionObjectReference": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ExternalMetricSource": {
+      "type": "object",
+      "properties": {
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ExternalMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HPAScalingPolicy": {
+      "type": "object",
+      "properties": {
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingPolicy",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HPAScalingRules": {
+      "type": "object",
+      "properties": {
+        "policies": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingPolicy",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingPolicy"
+          }
+        },
+        "selectPolicy": {
+          "type": "string"
+        },
+        "stabilizationWindowSeconds": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscaler": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "autoscaling/v2",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "default": "HorizontalPodAutoscaler",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerStatus"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerBehavior": {
+      "type": "object",
+      "properties": {
+        "scaleDown": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingRules",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules"
+        },
+        "scaleUp": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingRules",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerBehavior",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerCondition": {
+      "type": "object",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "existingJavaType": "String"
+        },
+        "message": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerCondition",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerList": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "autoscaling/v2",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscaler",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "default": "HorizontalPodAutoscalerList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler\u003e"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerSpec": {
+      "type": "object",
+      "properties": {
+        "behavior": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerBehavior",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerBehavior"
+        },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "metrics": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricSpec",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricSpec"
+          }
+        },
+        "minReplicas": {
+          "type": "integer"
+        },
+        "scaleTargetRef": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerStatus": {
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerCondition"
+          }
+        },
+        "currentMetrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricStatus",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricStatus"
+          }
+        },
+        "currentReplicas": {
+          "type": "integer"
+        },
+        "desiredReplicas": {
+          "type": "integer"
+        },
+        "lastScaleTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "existingJavaType": "String"
+        },
+        "observedGeneration": {
+          "type": "integer",
+          "existingJavaType": "Long"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricIdentifier": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricSpec": {
+      "type": "object",
+      "properties": {
+        "containerResource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricSource"
+        },
+        "external": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricSource"
+        },
+        "object": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricSource"
+        },
+        "pods": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricSource"
+        },
+        "resource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricSource"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricStatus": {
+      "type": "object",
+      "properties": {
+        "containerResource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricStatus"
+        },
+        "external": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricStatus"
+        },
+        "object": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricStatus"
+        },
+        "pods": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricStatus"
+        },
+        "resource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricStatus"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricTarget": {
+      "type": "object",
+      "properties": {
+        "averageUtilization": {
+          "type": "integer"
+        },
+        "averageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricValueStatus": {
+      "type": "object",
+      "properties": {
+        "averageUtilization": {
+          "type": "integer"
+        },
+        "averageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        },
+        "value": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ObjectMetricSource": {
+      "type": "object",
+      "properties": {
+        "describedObject": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ObjectMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "describedObject": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_PodsMetricSource": {
+      "type": "object",
+      "properties": {
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_PodsMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ResourceMetricSource": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ResourceMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricStatus",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -2050,7 +2599,7 @@
     },
     "BaseKubernetesList": {
       "$ref": "#/definitions/kubernetes_apimachinery_List",
-      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList"
+      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList"
     },
     "CreateOptions": {
       "$ref": "#/definitions/kubernetes_apimachinery_CreateOptions",
@@ -2119,6 +2668,14 @@
     "V1HorizontalPodAutoscalerList": {
       "$ref": "#/definitions/kubernetes_autoscaling_v1_HorizontalPodAutoscalerList",
       "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerList"
+    },
+    "V2HorizontalPodAutoscaler": {
+      "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscaler",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler"
+    },
+    "V2HorizontalPodAutoscalerList": {
+      "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList"
     },
     "V2beta1HorizontalPodAutoscaler": {
       "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_HorizontalPodAutoscaler",

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
@@ -253,7 +253,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata"
+            "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource"
           }
         },
         "kind": {
@@ -267,10 +267,10 @@
         }
       },
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource",
-        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.HasMetadata\u003e"
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.KubernetesResource\u003e"
       ]
     },
     "kubernetes_apimachinery_ListMeta": {
@@ -387,9 +387,6 @@
             "type": "string"
           },
           "existingJavaType": "java.util.Map\u003cString, String\u003e"
-        },
-        "clusterName": {
-          "type": "string"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -738,18 +735,10 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
-    "kubernetes_apimachinery_pkg_runtime_ImageRawExtension": {
-      "type": "object",
-      "additionalProperties": true,
-      "javaType": "io.fabric8.kubernetes.api.model.runtime.RawExtension",
-      "javaInterfaces": [
-        "io.fabric8.kubernetes.api.model.KubernetesResource"
-      ]
-    },
     "kubernetes_apimachinery_pkg_runtime_RawExtension": {
       "type": "object",
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -983,6 +972,566 @@
       },
       "additionalProperties": true,
       "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.ScaleStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ContainerResourceMetricSource": {
+      "type": "object",
+      "properties": {
+        "container": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ContainerResourceMetricStatus": {
+      "type": "object",
+      "properties": {
+        "container": {
+          "type": "string"
+        },
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_CrossVersionObjectReference": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ExternalMetricSource": {
+      "type": "object",
+      "properties": {
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ExternalMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HPAScalingPolicy": {
+      "type": "object",
+      "properties": {
+        "periodSeconds": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingPolicy",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HPAScalingRules": {
+      "type": "object",
+      "properties": {
+        "policies": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingPolicy",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingPolicy"
+          }
+        },
+        "selectPolicy": {
+          "type": "string"
+        },
+        "stabilizationWindowSeconds": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscaler": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "autoscaling/v2",
+          "required": true
+        },
+        "kind": {
+          "type": "string",
+          "default": "HorizontalPodAutoscaler",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ObjectMeta",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
+        },
+        "spec": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerSpec"
+        },
+        "status": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerStatus"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.HasMetadata",
+        "io.fabric8.kubernetes.api.model.Namespaced"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerBehavior": {
+      "type": "object",
+      "properties": {
+        "scaleDown": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingRules",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules"
+        },
+        "scaleUp": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingRules",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerBehavior",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerCondition": {
+      "type": "object",
+      "properties": {
+        "lastTransitionTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "existingJavaType": "String"
+        },
+        "message": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerCondition",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerList": {
+      "type": "object",
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "default": "autoscaling/v2",
+          "required": true
+        },
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscaler",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler"
+          }
+        },
+        "kind": {
+          "type": "string",
+          "default": "HorizontalPodAutoscalerList",
+          "required": true
+        },
+        "metadata": {
+          "$ref": "#/definitions/kubernetes_apimachinery_ListMeta",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.ListMeta"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource",
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler\u003e"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerSpec": {
+      "type": "object",
+      "properties": {
+        "behavior": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerBehavior",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerBehavior"
+        },
+        "maxReplicas": {
+          "type": "integer"
+        },
+        "metrics": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricSpec",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricSpec"
+          }
+        },
+        "minReplicas": {
+          "type": "integer"
+        },
+        "scaleTargetRef": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_HorizontalPodAutoscalerStatus": {
+      "type": "object",
+      "properties": {
+        "conditions": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerCondition"
+          }
+        },
+        "currentMetrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricStatus",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricStatus"
+          }
+        },
+        "currentReplicas": {
+          "type": "integer"
+        },
+        "desiredReplicas": {
+          "type": "integer"
+        },
+        "lastScaleTime": {
+          "$ref": "#/definitions/kubernetes_apimachinery_Time",
+          "existingJavaType": "String"
+        },
+        "observedGeneration": {
+          "type": "integer",
+          "existingJavaType": "Long"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricIdentifier": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricSpec": {
+      "type": "object",
+      "properties": {
+        "containerResource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricSource"
+        },
+        "external": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricSource"
+        },
+        "object": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricSource"
+        },
+        "pods": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricSource"
+        },
+        "resource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricSource"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricSpec",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricStatus": {
+      "type": "object",
+      "properties": {
+        "containerResource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricStatus"
+        },
+        "external": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricStatus"
+        },
+        "object": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricStatus"
+        },
+        "pods": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricStatus"
+        },
+        "resource": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricStatus"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricTarget": {
+      "type": "object",
+      "properties": {
+        "averageUtilization": {
+          "type": "integer"
+        },
+        "averageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        },
+        "type": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_MetricValueStatus": {
+      "type": "object",
+      "properties": {
+        "averageUtilization": {
+          "type": "integer"
+        },
+        "averageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        },
+        "value": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ObjectMetricSource": {
+      "type": "object",
+      "properties": {
+        "describedObject": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ObjectMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "describedObject": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_PodsMetricSource": {
+      "type": "object",
+      "properties": {
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_PodsMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricStatus",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ResourceMetricSource": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricSource",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
+    "kubernetes_autoscaling_v2_ResourceMetricStatus": {
+      "type": "object",
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricStatus",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -2050,7 +2599,7 @@
     },
     "BaseKubernetesList": {
       "$ref": "#/definitions/kubernetes_apimachinery_List",
-      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList"
+      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList"
     },
     "CreateOptions": {
       "$ref": "#/definitions/kubernetes_apimachinery_CreateOptions",
@@ -2119,6 +2668,14 @@
     "V1HorizontalPodAutoscalerList": {
       "$ref": "#/definitions/kubernetes_autoscaling_v1_HorizontalPodAutoscalerList",
       "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerList"
+    },
+    "V2HorizontalPodAutoscaler": {
+      "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscaler",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler"
+    },
+    "V2HorizontalPodAutoscalerList": {
+      "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerList"
     },
     "V2beta1HorizontalPodAutoscaler": {
       "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_HorizontalPodAutoscaler",
@@ -2221,9 +2778,12 @@
         "container": {
           "type": "string"
         },
-        "current": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricValueStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricValueStatus"
+        "currentAverageUtilization": {
+          "type": "integer"
+        },
+        "currentAverageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
         },
         "name": {
           "type": "string"
@@ -2312,12 +2872,12 @@
     "externalmetricsource": {
       "properties": {
         "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
         },
         "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
         }
       },
       "additionalProperties": true
@@ -2404,12 +2964,12 @@
     "horizontalpodautoscalerbehavior": {
       "properties": {
         "scaleDown": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HPAScalingRules",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HPAScalingRules"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingRules",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules"
         },
         "scaleUp": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HPAScalingRules",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HPAScalingRules"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_HPAScalingRules",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HPAScalingRules"
         }
       },
       "additionalProperties": true
@@ -2439,14 +2999,14 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "autoscaling/v2beta2",
+          "default": "autoscaling/v2",
           "required": true
         },
         "items": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscaler",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscaler"
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscaler",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscaler"
           }
         },
         "kind": {
@@ -2463,6 +3023,10 @@
     },
     "horizontalpodautoscalerspec": {
       "properties": {
+        "behavior": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscalerBehavior",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior"
+        },
         "maxReplicas": {
           "type": "integer"
         },
@@ -2470,35 +3034,24 @@
           "type": "array",
           "javaOmitEmpty": true,
           "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_MetricSpec",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.MetricSpec"
+            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricSpec",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricSpec"
           }
         },
         "minReplicas": {
           "type": "integer"
         },
         "scaleTargetRef": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_CrossVersionObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.CrossVersionObjectReference"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.CrossVersionObjectReference"
         }
       },
       "additionalProperties": true
     },
     "horizontalpodautoscalerstatus": {
       "properties": {
-        "conditions": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscalerCondition",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerCondition"
-          }
-        },
-        "currentMetrics": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricStatus",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricStatus"
-          }
+        "currentCPUUtilizationPercentage": {
+          "type": "integer"
         },
         "currentReplicas": {
           "type": "integer"
@@ -2548,9 +3101,6 @@
           "type": "integer"
         }
       },
-      "additionalProperties": true
-    },
-    "imagerawextension": {
       "additionalProperties": true
     },
     "info": {
@@ -2634,7 +3184,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata"
+            "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource"
           }
         },
         "kind": {
@@ -2754,24 +3304,24 @@
     "metricspec": {
       "properties": {
         "containerResource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ContainerResourceMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ContainerResourceMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ContainerResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ContainerResourceMetricSource"
         },
         "external": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ExternalMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ExternalMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ExternalMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ExternalMetricSource"
         },
         "object": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ObjectMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ObjectMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ObjectMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ObjectMetricSource"
         },
         "pods": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_PodsMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.PodsMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_PodsMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.PodsMetricSource"
         },
         "resource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ResourceMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ResourceMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ResourceMetricSource"
         },
         "type": {
           "type": "string"
@@ -2782,24 +3332,24 @@
     "metricstatus": {
       "properties": {
         "containerResource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ContainerResourceMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ContainerResourceMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricStatus"
         },
         "external": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ExternalMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ExternalMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricStatus"
         },
         "object": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ObjectMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ObjectMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricStatus"
         },
         "pods": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_PodsMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.PodsMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricStatus"
         },
         "resource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ResourceMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ResourceMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricStatus"
         },
         "type": {
           "type": "string"
@@ -2850,9 +3400,6 @@
             "type": "string"
           },
           "existingJavaType": "java.util.Map\u003cString, String\u003e"
-        },
-        "clusterName": {
-          "type": "string"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -2925,24 +3472,17 @@
     },
     "objectmetricsource": {
       "properties": {
-        "averageValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        "describedObject": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.CrossVersionObjectReference"
         },
-        "metricName": {
-          "type": "string"
-        },
-        "selector": {
-          "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
         },
         "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_CrossVersionObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.CrossVersionObjectReference"
-        },
-        "targetValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
         }
       },
       "additionalProperties": true
@@ -3036,16 +3576,13 @@
     },
     "podsmetricstatus": {
       "properties": {
-        "currentAverageValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricValueStatus"
         },
-        "metricName": {
-          "type": "string"
-        },
-        "selector": {
-          "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
         }
       },
       "additionalProperties": true

--- a/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
+++ b/kubernetes-model-generator/kubernetes-model-autoscaling/src/main/resources/schema/validation-schema.json
@@ -253,7 +253,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource"
+            "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata"
           }
         },
         "kind": {
@@ -267,10 +267,10 @@
         }
       },
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource",
-        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.KubernetesResource\u003e"
+        "io.fabric8.kubernetes.api.model.KubernetesResourceList\u003cio.fabric8.kubernetes.api.model.HasMetadata\u003e"
       ]
     },
     "kubernetes_apimachinery_ListMeta": {
@@ -387,6 +387,9 @@
             "type": "string"
           },
           "existingJavaType": "java.util.Map\u003cString, String\u003e"
+        },
+        "clusterName": {
+          "type": "string"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -735,10 +738,18 @@
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
     },
+    "kubernetes_apimachinery_pkg_runtime_ImageRawExtension": {
+      "type": "object",
+      "additionalProperties": true,
+      "javaType": "io.fabric8.kubernetes.api.model.runtime.RawExtension",
+      "javaInterfaces": [
+        "io.fabric8.kubernetes.api.model.KubernetesResource"
+      ]
+    },
     "kubernetes_apimachinery_pkg_runtime_RawExtension": {
       "type": "object",
       "additionalProperties": true,
-      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource",
+      "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata",
       "javaInterfaces": [
         "io.fabric8.kubernetes.api.model.KubernetesResource"
       ]
@@ -2599,7 +2610,7 @@
     },
     "BaseKubernetesList": {
       "$ref": "#/definitions/kubernetes_apimachinery_List",
-      "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesList"
+      "existingJavaType": "io.fabric8.kubernetes.api.model.BaseKubernetesList"
     },
     "CreateOptions": {
       "$ref": "#/definitions/kubernetes_apimachinery_CreateOptions",
@@ -2763,12 +2774,9 @@
         "name": {
           "type": "string"
         },
-        "targetAverageUtilization": {
-          "type": "integer"
-        },
-        "targetAverageValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        "target": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
         }
       },
       "additionalProperties": true
@@ -2778,12 +2786,9 @@
         "container": {
           "type": "string"
         },
-        "currentAverageUtilization": {
-          "type": "integer"
-        },
-        "currentAverageValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricValueStatus"
         },
         "name": {
           "type": "string"
@@ -2871,33 +2876,33 @@
     },
     "externalmetricsource": {
       "properties": {
-        "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
-        },
-        "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
-        }
-      },
-      "additionalProperties": true
-    },
-    "externalmetricstatus": {
-      "properties": {
-        "currentAverageValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
-        },
-        "currentValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
-        },
         "metricName": {
           "type": "string"
         },
         "metricSelector": {
           "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
           "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        },
+        "targetAverageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        },
+        "targetValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        }
+      },
+      "additionalProperties": true
+    },
+    "externalmetricstatus": {
+      "properties": {
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricValueStatus"
+        },
+        "metric": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
         }
       },
       "additionalProperties": true
@@ -2938,7 +2943,7 @@
       "properties": {
         "apiVersion": {
           "type": "string",
-          "default": "autoscaling/v2beta2",
+          "default": "autoscaling/v1",
           "required": true
         },
         "kind": {
@@ -2951,12 +2956,12 @@
           "existingJavaType": "io.fabric8.kubernetes.api.model.ObjectMeta"
         },
         "spec": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscalerSpec",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerSpec"
+          "$ref": "#/definitions/kubernetes_autoscaling_v1_HorizontalPodAutoscalerSpec",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerSpec"
         },
         "status": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscalerStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v1_HorizontalPodAutoscalerStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.HorizontalPodAutoscalerStatus"
         }
       },
       "additionalProperties": true
@@ -3023,35 +3028,38 @@
     },
     "horizontalpodautoscalerspec": {
       "properties": {
-        "behavior": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_HorizontalPodAutoscalerBehavior",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.HorizontalPodAutoscalerBehavior"
-        },
         "maxReplicas": {
           "type": "integer"
-        },
-        "metrics": {
-          "type": "array",
-          "javaOmitEmpty": true,
-          "items": {
-            "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricSpec",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricSpec"
-          }
         },
         "minReplicas": {
           "type": "integer"
         },
         "scaleTargetRef": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_CrossVersionObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.CrossVersionObjectReference"
+          "$ref": "#/definitions/kubernetes_autoscaling_v1_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v1.CrossVersionObjectReference"
+        },
+        "targetCPUUtilizationPercentage": {
+          "type": "integer"
         }
       },
       "additionalProperties": true
     },
     "horizontalpodautoscalerstatus": {
       "properties": {
-        "currentCPUUtilizationPercentage": {
-          "type": "integer"
+        "conditions": {
+          "type": "array",
+          "javaOmitEmpty": true,
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_HorizontalPodAutoscalerCondition",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.HorizontalPodAutoscalerCondition"
+          }
+        },
+        "currentMetrics": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricStatus",
+            "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricStatus"
+          }
         },
         "currentReplicas": {
           "type": "integer"
@@ -3101,6 +3109,9 @@
           "type": "integer"
         }
       },
+      "additionalProperties": true
+    },
+    "imagerawextension": {
       "additionalProperties": true
     },
     "info": {
@@ -3184,7 +3195,7 @@
           "type": "array",
           "items": {
             "$ref": "#/definitions/kubernetes_apimachinery_pkg_runtime_RawExtension",
-            "existingJavaType": "io.fabric8.kubernetes.api.model.KubernetesResource"
+            "existingJavaType": "io.fabric8.kubernetes.api.model.HasMetadata"
           }
         },
         "kind": {
@@ -3304,24 +3315,24 @@
     "metricspec": {
       "properties": {
         "containerResource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ContainerResourceMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ContainerResourceMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricSource"
         },
         "external": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ExternalMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ExternalMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricSource"
         },
         "object": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ObjectMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ObjectMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricSource"
         },
         "pods": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_PodsMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.PodsMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricSource"
         },
         "resource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta1_ResourceMetricSource",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta1.ResourceMetricSource"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricSource",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricSource"
         },
         "type": {
           "type": "string"
@@ -3332,24 +3343,24 @@
     "metricstatus": {
       "properties": {
         "containerResource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ContainerResourceMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ContainerResourceMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ContainerResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ContainerResourceMetricStatus"
         },
         "external": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ExternalMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ExternalMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ExternalMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ExternalMetricStatus"
         },
         "object": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ObjectMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ObjectMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ObjectMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ObjectMetricStatus"
         },
         "pods": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_PodsMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.PodsMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_PodsMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.PodsMetricStatus"
         },
         "resource": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2_ResourceMetricStatus",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.ResourceMetricStatus"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_ResourceMetricStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.ResourceMetricStatus"
         },
         "type": {
           "type": "string"
@@ -3400,6 +3411,9 @@
             "type": "string"
           },
           "existingJavaType": "java.util.Map\u003cString, String\u003e"
+        },
+        "clusterName": {
+          "type": "string"
         },
         "creationTimestamp": {
           "$ref": "#/definitions/kubernetes_apimachinery_Time",
@@ -3473,16 +3487,16 @@
     "objectmetricsource": {
       "properties": {
         "describedObject": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_CrossVersionObjectReference",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.CrossVersionObjectReference"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_CrossVersionObjectReference",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.CrossVersionObjectReference"
         },
         "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricIdentifier",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricIdentifier"
         },
         "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+          "$ref": "#/definitions/kubernetes_autoscaling_v2_MetricTarget",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2.MetricTarget"
         }
       },
       "additionalProperties": true
@@ -3563,13 +3577,16 @@
     },
     "podsmetricsource": {
       "properties": {
-        "metric": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricIdentifier",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricIdentifier"
+        "metricName": {
+          "type": "string"
         },
-        "target": {
-          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricTarget",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricTarget"
+        "selector": {
+          "$ref": "#/definitions/kubernetes_apimachinery_LabelSelector",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.LabelSelector"
+        },
+        "targetAverageValue": {
+          "$ref": "#/definitions/kubernetes_resource_Quantity",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
         }
       },
       "additionalProperties": true
@@ -3623,12 +3640,9 @@
     },
     "resourcemetricstatus": {
       "properties": {
-        "currentAverageUtilization": {
-          "type": "integer"
-        },
-        "currentAverageValue": {
-          "$ref": "#/definitions/kubernetes_resource_Quantity",
-          "existingJavaType": "io.fabric8.kubernetes.api.model.Quantity"
+        "current": {
+          "$ref": "#/definitions/kubernetes_autoscaling_v2beta2_MetricValueStatus",
+          "existingJavaType": "io.fabric8.kubernetes.api.model.autoscaling.v2beta2.MetricValueStatus"
         },
         "name": {
           "type": "string"

--- a/kubernetes-model-generator/kubernetes-model-core/pom.xml
+++ b/kubernetes-model-generator/kubernetes-model-core/pom.xml
@@ -89,6 +89,7 @@
               io.fabric8.kubernetes.api.model.autoscaling.v1,
               io.fabric8.kubernetes.api.model.autoscaling.v2beta1,
               io.fabric8.kubernetes.api.model.autoscaling.v2beta2,
+              io.fabric8.kubernetes.api.model.autoscaling.v2,
               io.fabric8.kubernetes.api.model.batch.v1,
               io.fabric8.kubernetes.api.model.batch.v1beta1,
               io.fabric8.kubernetes.api.model.certificates.v1,


### PR DESCRIPTION
## Description
- This adds support for autoscaling v2 api which will help us with kubernetes 1.27
- The v2 autoscaling classes were copied over from the newer 6.2.0 and the dsls were copied over from the beta client and modified for v2

