### PR TITLE
fix: Fix the build for 5.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Core versions -->
-    <sundrio.version>0.50.4</sundrio.version>
+    <sundrio.version>0.100.3</sundrio.version>
     <okhttp.version>3.12.12</okhttp.version>
     <okhttp.bundle.version>3.12.1_1</okhttp.bundle.version>
     <okio.version>1.15.0</okio.version>


### PR DESCRIPTION
## Description
- Bump sundrio version to 0.100.3 to address build failure issues with maven 3.8.5
- Found the fix here https://github.com/OpenFeign/feign/issues/1833
