### PR TITLE
fix: Fix the build for 5.12.2

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -6,6 +6,7 @@ enabled: true
 env:
   SET_VERSION_OVERRIDE: $GIT_BRANCH-SNAPSHOT
   MAVEN_OPTS: -Xmx4096m
+  MAVEN_VERSION: "3.8.4"
   MAVEN_ARGS: -DskipTests -am -pl kubernetes-server-mock,kubernetes-model-generator,kubernetes-model-generator/kubernetes-model-apiextensions,kubernetes-client
 
 buildResources:

--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -1,12 +1,11 @@
 buildpack:
   name: Blazar-Buildpack-Java-single-module
-
+  branch: kubernetes_client_changes
 enabled: true
 
 env:
   SET_VERSION_OVERRIDE: $GIT_BRANCH-SNAPSHOT
   MAVEN_OPTS: -Xmx4096m
-  MAVEN_VERSION: "3.8.4"
   MAVEN_ARGS: -DskipTests -am -pl kubernetes-server-mock,kubernetes-model-generator,kubernetes-model-generator/kubernetes-model-apiextensions,kubernetes-client
 
 buildResources:


### PR DESCRIPTION
## Description
- A alternate approach to https://github.com/HubSpot/kubernetes-client/pull/115 where the buildpack was put on a branch to handle this particular build. Since we are later moving to 6.8 this solves the case in the meantime and does not cause any other dependency issues.
