### PR TITLE
Draft: Fix access rules

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/utils/Properties.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/utils/Properties.java
@@ -1,0 +1,110 @@
+package io.fabric8.crd.generator.utils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.sundr.model.AnnotationRef;
+import io.sundr.model.Method;
+import io.sundr.model.Property;
+import io.sundr.model.PropertyBuilder;
+import io.sundr.model.TypeDef;
+
+// TODO: We should use the visibility settings from the object mapper that is being used.
+public class Properties {
+  // Get a list of visible properties.
+  // Returns public fields as well as private fields that are accessible
+  // through get<fieldName> or is<fieldName> methods
+  public static List<Property> getVisibleProperties(TypeDef def) {
+    List<Property> props = new ArrayList<>();
+    if (def.getFullyQualifiedName().startsWith("java.")) {
+      return props;
+    }
+
+    // Get public properties
+    for (Property p : def.getProperties()) {
+      if (!p.isPublic() || p.isTransient()) {
+        continue;
+      }
+      props.add(p);
+    }
+
+    // Get getters
+    for (Method m : def.getMethods()) {
+      if (
+        !m.isPublic() || m.isTransient() || m.isStatic() ||
+        m.getName().equals("getClass") ||
+        !(m.getName().startsWith("get") || m.getName().startsWith("is"))
+      ) {
+        continue;
+      }
+
+      String propName = propertyNameForMethod(m);
+      // Find the property for the getter.
+      boolean found = false;
+      for (Property p : def.getProperties()) {
+        if (p.getName().equals(propName)) {
+
+          List<AnnotationRef> mergedAnnotations = Stream.concat(
+              p.getAnnotations().stream(),
+              m.getAnnotations().stream()
+            )
+            .collect(Collectors.toList());
+
+          Property newProp =  new PropertyBuilder(p).withAnnotations(mergedAnnotations).build();
+          props.add(newProp);
+
+          found = true;
+          break;
+        }
+      }
+
+      if (!found) {
+        props.add(propertyFromMethod(m));
+      }
+    }
+
+    return props;
+  }
+
+  private static Property propertyFromMethod(Method m) {
+    return new PropertyBuilder()
+      .withName(propertyNameForMethod(m))
+      .withTypeRef(m.getReturnType())
+      .withAnnotations(m.getAnnotations())
+      .withModifiers(m.getModifiers())
+      .withAttributes(m.getAttributes())
+      .withComments(m.getComments())
+      .build();
+  }
+
+  private static String propertyNameForMethod(Method method) {
+    String name = method.getName();
+    if (name.equals("get") || name.equals("is")) {
+      return name;
+    }
+
+    if (name.startsWith("get")) {
+      return lowerFirstLetter(removePrefix(name, "get"));
+    } else if (name.startsWith("is")) {
+      return lowerFirstLetter(removePrefix(name, "is"));
+    }
+    return name;
+  }
+
+  private static String removePrefix(String text, String prefix) {
+    if (text.startsWith(prefix)) {
+      return text.substring(prefix.length());
+    }
+    return text;
+  }
+
+  private static String lowerFirstLetter(String text) {
+    if (text.isEmpty()) {
+      return text;
+    }
+
+    return Character.toLowerCase(text.charAt(0)) + text.substring(1);
+  }
+}

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedMultiPropertyPathDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedMultiPropertyPathDetector.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.generator.visitor;
 
+import io.fabric8.crd.generator.utils.Properties;
 import io.fabric8.crd.generator.utils.Types;
 import io.sundr.builder.TypedVisitor;
 import io.sundr.model.ClassRef;
@@ -56,7 +57,7 @@ public class AnnotatedMultiPropertyPathDetector extends TypedVisitor<TypeDefBuil
   @Override
   public void visit(TypeDefBuilder builder) {
     TypeDef type = builder.build();
-    final List<Property> props = type.getProperties();
+    final List<Property> props = Properties.getVisibleProperties(type);
     for (Property p : props) {
         if (parents.contains(p)) {
           continue;
@@ -75,7 +76,7 @@ public class AnnotatedMultiPropertyPathDetector extends TypedVisitor<TypeDefBuil
         if (!parents.contains(p)) {
           ClassRef classRef = (ClassRef) p.getTypeRef();
           TypeDef propertyType = Types.typeDefFrom(classRef);
-          if (!propertyType.isEnum()) {
+          if (!(propertyType.isEnum() || propertyType.getFullyQualifiedName().startsWith("java."))) {
             List<Property> newParents = new ArrayList<>(parents);
             newParents.add(p);
             new TypeDefBuilder(propertyType)

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/accessible/AccessibleClass.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/accessible/AccessibleClass.java
@@ -1,0 +1,23 @@
+package io.fabric8.crd.example.accessible;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AccessibleClass {
+  private int gettable;
+  private String invisible;
+  public String visible;
+  public transient volatile Foo foo = new Foo();
+
+  @JsonProperty("gettable")
+  public int getGettable() {
+    return gettable;
+  }
+
+  public boolean isTruthy() {
+    return true;
+  }
+
+  public static class Foo {
+    public String bar;
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -25,15 +25,15 @@ import javax.validation.constraints.NotNull;
 public class AnnotatedSpec {
   @JsonProperty("from-field")
   @JsonPropertyDescription("from-field-description")
-  private String field;
+  public String field;
   private int foo;
   @JsonProperty
-  private String unnamed;
+  public String unnamed;
   @NotNull
   private boolean emptySetter;
-  private AnnotatedEnum anEnum;
+  public AnnotatedEnum anEnum;
   @Min(0) // a non-string value attribute
-  private int sizedField;
+  public int sizedField;
 
   @JsonIgnore
   private int ignoredFoo;
@@ -59,6 +59,10 @@ public class AnnotatedSpec {
   @JsonProperty
   public void setEmptySetter(boolean emptySetter) {
     this.emptySetter = emptySetter;
+  }
+
+  public boolean isEmptySetter() {
+    return emptySetter;
   }
 
   public enum AnnotatedEnum {

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/person/Address.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/person/Address.java
@@ -16,11 +16,11 @@
 package io.fabric8.crd.example.person;
 
 public class Address {
-  private String street;
-  private int number;
-  private String zip;
-  private String country;
-  private Type type;
+  public String street;
+  public int number;
+  public String zip;
+  public String country;
+  public Type type;
 
   public enum Type {
     home, work

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/person/Person.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/person/Person.java
@@ -20,15 +20,24 @@ import java.util.Optional;
 
 public class Person {
 
-  private String firstName;
-  private Optional<String> middleName;
-  private String lastName;
-  private int birthYear;
-  private List<String> hobbies;
-  private AddressList addresses;
-  private Type type;
+  public String firstName;
+  public Optional<String> middleName;
+  public String lastName;
+  public int birthYear;
+  public List<String> hobbies;
+  public AddressList addresses;
+  public Type type;
+  public transient Foo transientFoo;
+
+  protected static Foo builder() {
+    return new Foo();
+  }
 
   public enum Type {
     crazy, crazier
+  }
+
+  public static class Foo {
+    public static String bar;
   }
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/utils/PropertiesTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/utils/PropertiesTest.java
@@ -1,0 +1,50 @@
+package io.fabric8.crd.generator.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.crd.example.accessible.AccessibleClass;
+import io.fabric8.crd.example.webserver.WebServerWithStatusProperty;
+import io.sundr.model.Property;
+import io.sundr.model.TypeDef;
+
+public class PropertiesTest {
+  @Test
+  public void testClassWithNoPublicProperties() {
+    TypeDef def = Types.typeDefFrom(WebServerWithStatusProperty.class);
+    List<Property> props = Properties.getVisibleProperties(def);
+    assertEquals(0, props.size());
+  }
+
+  private Property findByName(List<Property> props, String name) {
+    return props.stream()
+      .filter(p -> p.getName().equals(name))
+      .findAny()
+      .get();
+  }
+
+  @Test
+  public void testClassWithMixedVisibility() {
+    TypeDef def = Types.typeDefFrom(AccessibleClass.class);
+    List<Property> props = Properties.getVisibleProperties(def);
+    assertEquals(3, props.size());
+
+    Property publicProp = findByName(props, "visible");
+    assertTrue(publicProp.isPublic());
+
+    Property getterProp = findByName(props, "gettable");
+    assertTrue(getterProp.isPrivate());
+    // Got annotations from getter method
+    assertEquals(1, getterProp.getAnnotations().size());
+
+    Property boolProp = findByName(props, "truthy");
+    assertFalse(boolProp.isPrivate());
+    // Got annotations from getter method
+    assertEquals(0, boolProp.getAnnotations().size());
+  }
+}

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -50,6 +50,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.fabric8.kubernetes.client.internal.PatchUtils.patchMapper;
 
@@ -280,6 +281,8 @@ public class OperationSupport {
     if (dryRun) {
       deleteOptions.setDryRun(Collections.singletonList("All"));
     }
+
+    LOG.debug("Executing delete for {} with {} grace period seconds", requestUrl, gracePeriodSeconds);
 
     HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder().delete(JSON, JSON_MAPPER.writeValueAsString(deleteOptions)).url(requestUrl);
     handleResponse(requestBuilder, null, Collections.<String, String>emptyMap());

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/base/OperationSupport.java
@@ -282,9 +282,10 @@ public class OperationSupport {
       deleteOptions.setDryRun(Collections.singletonList("All"));
     }
 
-    LOG.debug("Executing delete for {} with {} grace period seconds", requestUrl, gracePeriodSeconds);
+    String deleteOptionsBody = JSON_MAPPER.writeValueAsString(deleteOptions);
+    LOG.debug("Executing delete for {} with body {}", requestUrl, deleteOptionsBody);
 
-    HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder().delete(JSON, JSON_MAPPER.writeValueAsString(deleteOptions)).url(requestUrl);
+    HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder().delete(JSON, deleteOptionsBody).url(requestUrl);
     handleResponse(requestBuilder, null, Collections.<String, String>emptyMap());
   }
 


### PR DESCRIPTION
- Fix access rules to only look at private fields for schema generation.
- Fix a stack overflow where we were introspecting `Object.class` and `Object.getClass()`.
- Avoid a lot of work by ignoring properties on java.lang.* classes