### PR TITLE
back port annotation support for defaults and preserve-unknown-fields

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -123,24 +123,24 @@ public abstract class AbstractJsonSchema<T, B> {
   }
 
   protected static class SchemaPropsOptions {
-    final Optional<Double> min;
-    final Optional<Double> max;
-    final Optional<String> pattern;
+    final Double min;
+    final Double max;
+    final String pattern;
     final boolean nullable;
     final boolean required;
 
     final boolean preserveUnknownFields;
 
     SchemaPropsOptions() {
-      min = Optional.empty();
-      max = Optional.empty();
-      pattern = Optional.empty();
+      min = null;
+      max = null;
+      pattern = null;
       nullable = false;
       required = false;
       preserveUnknownFields = false;
     }
 
-    public SchemaPropsOptions(Optional<Double> min, Optional<Double> max, Optional<String> pattern,
+    public SchemaPropsOptions(Double min, Double max, String pattern,
         boolean nullable, boolean required, boolean preserveUnknownFields) {
       this.min = min;
       this.max = max;
@@ -151,15 +151,15 @@ public abstract class AbstractJsonSchema<T, B> {
     }
 
     public Optional<Double> getMin() {
-      return min;
+      return Optional.ofNullable(min);
     }
 
     public Optional<Double> getMax() {
-      return max;
+      return Optional.ofNullable(max);
     }
 
     public Optional<String> getPattern() {
-      return pattern;
+      return Optional.ofNullable(pattern);
     }
 
     public boolean isNullable() {
@@ -336,7 +336,7 @@ public abstract class AbstractJsonSchema<T, B> {
           facade.pattern,
           facade.nullable,
           facade.required,
-          facade.preserveSelfUnknownFields);
+          facade.preserveUnknownFields);
 
       addProperty(possiblyRenamedProperty, builder, possiblyUpdatedSchema, options);
     }
@@ -361,14 +361,13 @@ public abstract class AbstractJsonSchema<T, B> {
     private final String propertyName;
     private final String type;
     private String renamedTo;
-    private Optional<Double> min;
-    private Optional<Double> max;
-    private Optional<String> pattern;
+    private Double min;
+    private Double max;
+    private String pattern;
     private boolean nullable;
     private boolean required;
     private boolean ignored;
     private boolean preserveUnknownFields;
-    private boolean preserveSelfUnknownFields;
     private String description;
     private TypeRef schemaFrom;
 
@@ -377,10 +376,6 @@ public abstract class AbstractJsonSchema<T, B> {
       this.name = name;
       this.propertyName = propertyName;
       type = isMethod ? "accessor" : "field";
-
-      min = Optional.empty();
-      max = Optional.empty();
-      pattern = Optional.empty();
     }
 
     static PropertyOrAccessor fromProperty(Property property) {
@@ -398,13 +393,13 @@ public abstract class AbstractJsonSchema<T, B> {
             nullable = true;
             break;
           case ANNOTATION_MAX:
-            max = Optional.of((Double) a.getParameters().get(VALUE));
+            max = (Double) a.getParameters().get(VALUE);
             break;
           case ANNOTATION_MIN:
-            min = Optional.of((Double) a.getParameters().get(VALUE));
+            min = (Double) a.getParameters().get(VALUE);
             break;
           case ANNOTATION_PATTERN:
-            pattern = Optional.of((String) a.getParameters().get(VALUE));
+            pattern = (String) a.getParameters().get(VALUE);
             break;
           case ANNOTATION_NOT_NULL:
             LOGGER.warn("Annotation: {} on property: {} is deprecated. Please use: {} instead", ANNOTATION_NOT_NULL, name,
@@ -431,10 +426,8 @@ public abstract class AbstractJsonSchema<T, B> {
             break;
           case ANNOTATION_JSON_ANY_GETTER:
           case ANNOTATION_JSON_ANY_SETTER:
-            preserveUnknownFields = true;
-            break;
           case ANNOTATION_PERSERVE_UNKNOWN_FIELDS:
-            preserveSelfUnknownFields = true;
+            preserveUnknownFields = true;
             break;
           case ANNOTATION_SCHEMA_FROM:
             schemaFrom = extractClassRef(a.getParameters().get("type"));
@@ -452,15 +445,15 @@ public abstract class AbstractJsonSchema<T, B> {
     }
 
     public Optional<Double> getMax() {
-      return max;
+      return Optional.ofNullable(max);
     }
 
     public Optional<Double> getMin() {
-      return min;
+      return Optional.ofNullable(min);
     }
 
     public Optional<String> getPattern() {
-      return pattern;
+      return Optional.ofNullable(pattern);
     }
 
     public boolean isRequired() {
@@ -473,10 +466,6 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public boolean isPreserveUnknownFields() {
       return preserveUnknownFields;
-    }
-
-    public boolean isPreserveSelfUnknownFields() {
-      return preserveSelfUnknownFields;
     }
 
     public String getDescription() {
@@ -511,14 +500,13 @@ public abstract class AbstractJsonSchema<T, B> {
     private final Set<InternalSchemaSwap> matchedSchemaSwaps;
     private String renamedTo;
     private String description;
-    private Optional<Double> min;
-    private Optional<Double> max;
-    private Optional<String> pattern;
+    private Double min;
+    private Double max;
+    private String pattern;
     private boolean nullable;
     private boolean required;
     private boolean ignored;
     private boolean preserveUnknownFields;
-    private boolean preserveSelfUnknownFields;
     private final Property original;
     private String nameContributedBy;
     private String descriptionContributedBy;
@@ -543,9 +531,9 @@ public abstract class AbstractJsonSchema<T, B> {
       if (method != null) {
         propertyOrAccessors.add(PropertyOrAccessor.fromMethod(method, name));
       }
-      min = Optional.empty();
-      max = Optional.empty();
-      pattern = Optional.empty();
+      min = null;
+      max = null;
+      pattern = null;
     }
 
     public Property process() {
@@ -581,18 +569,9 @@ public abstract class AbstractJsonSchema<T, B> {
             LOGGER.debug("Description for property {} has already been contributed by: {}", name, descriptionContributedBy);
           }
         }
-
-        if (p.getMin().isPresent()) {
-          min = p.getMin();
-        }
-
-        if (p.getMax().isPresent()) {
-          max = p.getMax();
-        }
-
-        if (p.getPattern().isPresent()) {
-          pattern = p.getPattern();
-        }
+        min = p.getMin().orElse(min);
+        max = p.getMax().orElse(max);
+        pattern = p.getPattern().orElse(pattern);
 
         if (p.isNullable()) {
           nullable = true;
@@ -604,13 +583,7 @@ public abstract class AbstractJsonSchema<T, B> {
           ignored = true;
         }
 
-        if (p.isPreserveUnknownFields()) {
-          preserveUnknownFields = true;
-        }
-
-        if (p.isPreserveSelfUnknownFields()) {
-          preserveSelfUnknownFields = true;
-        }
+        preserveUnknownFields = p.isPreserveUnknownFields() || preserveUnknownFields;
 
         if (p.contributeSchemaFrom()) {
           schemaFrom = p.getSchemaFrom();

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -588,7 +588,7 @@ public abstract class AbstractJsonSchema<T, B> {
             LOGGER.debug("Description for property {} has already been contributed by: {}", name, descriptionContributedBy);
           }
         }
-        defaultValue = p.getDefault().orElse(null);
+        defaultValue = p.getDefault().orElse(defaultValue);
         min = p.getMin().orElse(min);
         max = p.getMax().orElse(max);
         pattern = p.getPattern().orElse(pattern);

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -91,6 +91,7 @@ public abstract class AbstractJsonSchema<T, B> {
   public static final String ANNOTATION_REQUIRED = "io.fabric8.generator.annotation.Required";
   public static final String ANNOTATION_NOT_NULL = "javax.validation.constraints.NotNull";
   public static final String ANNOTATION_SCHEMA_FROM = "io.fabric8.crd.generator.annotation.SchemaFrom";
+  public static final String ANNOTATION_PERSERVE_UNKNOWN_FIELDS = "io.fabric8.crd.generator.annotation.PreserveUnknownFields";
   public static final String ANNOTATION_SCHEMA_SWAP = "io.fabric8.crd.generator.annotation.SchemaSwap";
 
   public static final String JSON_NODE_TYPE = "com.fasterxml.jackson.databind.JsonNode";
@@ -128,21 +129,25 @@ public abstract class AbstractJsonSchema<T, B> {
     final boolean nullable;
     final boolean required;
 
+    final boolean preserveUnknownFields;
+
     SchemaPropsOptions() {
       min = Optional.empty();
       max = Optional.empty();
       pattern = Optional.empty();
       nullable = false;
       required = false;
+      preserveUnknownFields = false;
     }
 
     public SchemaPropsOptions(Optional<Double> min, Optional<Double> max, Optional<String> pattern,
-        boolean nullable, boolean required) {
+        boolean nullable, boolean required, boolean preserveUnknownFields) {
       this.min = min;
       this.max = max;
       this.pattern = pattern;
       this.nullable = nullable;
       this.required = required;
+      this.preserveUnknownFields = preserveUnknownFields;
     }
 
     public Optional<Double> getMin() {
@@ -163,6 +168,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public boolean getRequired() {
       return nullable;
+    }
+
+    public boolean isPreserveUnknownFields() {
+      return preserveUnknownFields;
     }
   }
 
@@ -326,7 +335,8 @@ public abstract class AbstractJsonSchema<T, B> {
           facade.max,
           facade.pattern,
           facade.nullable,
-          facade.required);
+          facade.required,
+          facade.preserveSelfUnknownFields);
 
       addProperty(possiblyRenamedProperty, builder, possiblyUpdatedSchema, options);
     }
@@ -358,6 +368,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean required;
     private boolean ignored;
     private boolean preserveUnknownFields;
+    private boolean preserveSelfUnknownFields;
     private String description;
     private TypeRef schemaFrom;
 
@@ -422,6 +433,9 @@ public abstract class AbstractJsonSchema<T, B> {
           case ANNOTATION_JSON_ANY_SETTER:
             preserveUnknownFields = true;
             break;
+          case ANNOTATION_PERSERVE_UNKNOWN_FIELDS:
+            preserveSelfUnknownFields = true;
+            break;
           case ANNOTATION_SCHEMA_FROM:
             schemaFrom = extractClassRef(a.getParameters().get("type"));
             break;
@@ -459,6 +473,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public boolean isPreserveUnknownFields() {
       return preserveUnknownFields;
+    }
+
+    public boolean isPreserveSelfUnknownFields() {
+      return preserveSelfUnknownFields;
     }
 
     public String getDescription() {
@@ -500,6 +518,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean required;
     private boolean ignored;
     private boolean preserveUnknownFields;
+    private boolean preserveSelfUnknownFields;
     private final Property original;
     private String nameContributedBy;
     private String descriptionContributedBy;
@@ -587,6 +606,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
         if (p.isPreserveUnknownFields()) {
           preserveUnknownFields = true;
+        }
+
+        if (p.isPreserveSelfUnknownFields()) {
+          preserveSelfUnknownFields = true;
         }
 
         if (p.contributeSchemaFrom()) {

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/CRDGenerator.java
@@ -41,7 +41,7 @@ public class CRDGenerator {
   private CRDOutput<? extends OutputStream> output;
   private Map<String, CustomResourceInfo> infos;
 
-  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
+  public static final ObjectMapper YAML_MAPPER = new ObjectMapper(
     new YAMLFactory()
       .enable(Feature.MINIMIZE_QUOTES)
       .enable(Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS)

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
@@ -18,7 +18,7 @@ package io.fabric8.crd.generator.annotation;
 import java.lang.annotation.*;
 
 /*
- * Used to tweak the behavior of the crd-generator
+ * Used to emit 'x-kubernetes-preserve-unknown-fields'
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2022 Red Hat, Inc.
+ * Copyright (C) 2015 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/annotation/PreserveUnknownFields.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2015 Red Hat, Inc.
+ * Copyright (C) 2022 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,17 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.fabric8.crd.example.extraction;
+package io.fabric8.crd.generator.annotation;
 
-import io.fabric8.crd.generator.annotation.PreserveUnknownFields;
-import io.fabric8.crd.generator.annotation.SchemaFrom;
+import java.lang.annotation.*;
 
-public class ExtractionSpec {
-
-  @SchemaFrom(type = FooExtractor.class)
-  private Foo foo;
-
-  @PreserveUnknownFields
-  private Foo bar;
-
+/*
+ * Used to tweak the behavior of the crd-generator
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PreserveUnknownFields {
 }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -66,6 +66,10 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
         schema.setNullable(true);
       }
 
+      if (options.isPreserveUnknownFields()) {
+        schema.setXKubernetesPreserveUnknownFields(true);
+      }
+
       builder.addToProperties(property.getName(), schema);
     }
   }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1/JsonSchema.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.generator.v1;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.generator.AbstractJsonSchema;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
@@ -24,6 +25,8 @@ import io.sundr.model.TypeDef;
 import io.sundr.model.TypeRef;
 
 import java.util.List;
+
+import static io.fabric8.crd.generator.CRDGenerator.YAML_MAPPER;
 
 public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPropsBuilder> {
 
@@ -58,6 +61,13 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   public void addProperty(Property property, JSONSchemaPropsBuilder builder,
       JSONSchemaProps schema, SchemaPropsOptions options) {
     if (schema != null) {
+      options.getDefault().ifPresent(s -> {
+        try {
+          schema.setDefault(YAML_MAPPER.readTree(s));
+        } catch (JsonProcessingException e) {
+          throw new IllegalArgumentException("Cannot parse default value: '" + s + "' as valid YAML.");
+        }
+      });
       options.getMin().ifPresent(schema::setMinimum);
       options.getMax().ifPresent(schema::setMaximum);
       options.getPattern().ifPresent(schema::setPattern);

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -67,6 +67,10 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
         schema.setNullable(true);
       }
 
+      if (options.isPreserveUnknownFields()) {
+        schema.setXKubernetesPreserveUnknownFields(true);
+      }
+
       builder.addToProperties(property.getName(), schema);
     }
   }

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/v1beta1/JsonSchema.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.generator.v1beta1;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.generator.AbstractJsonSchema;
 import io.fabric8.kubernetes.api.model.apiextensions.v1beta1.JSONSchemaProps;
@@ -24,6 +25,8 @@ import io.sundr.model.TypeDef;
 import io.sundr.model.TypeRef;
 
 import java.util.List;
+
+import static io.fabric8.crd.generator.CRDGenerator.YAML_MAPPER;
 
 public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPropsBuilder> {
 
@@ -59,6 +62,13 @@ public class JsonSchema extends AbstractJsonSchema<JSONSchemaProps, JSONSchemaPr
   public void addProperty(Property property, JSONSchemaPropsBuilder builder,
       JSONSchemaProps schema, SchemaPropsOptions options) {
     if (schema != null) {
+      options.getDefault().ifPresent(s -> {
+        try {
+          schema.setDefault(YAML_MAPPER.readTree(s));
+        } catch (JsonProcessingException e) {
+          throw new IllegalArgumentException("Cannot parse default value: '" + s + "' as valid YAML.");
+        }
+      });
       options.getMin().ifPresent(schema::setMinimum);
       options.getMax().ifPresent(schema::setMaximum);
       options.getPattern().ifPresent(schema::setPattern);

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -18,6 +18,7 @@ package io.fabric8.crd.example.annotated;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import io.fabric8.generator.annotation.Default;
 import io.fabric8.generator.annotation.Max;
 import io.fabric8.generator.annotation.Min;
 import io.fabric8.generator.annotation.Nullable;
@@ -37,7 +38,8 @@ public class AnnotatedSpec {
   private int max;
   private String singleDigit;
   private String nullable;
-  @NotNull
+  private String defaultValue;
+  @Required
   private boolean emptySetter;
   @Required
   private boolean emptySetter2;
@@ -84,6 +86,11 @@ public class AnnotatedSpec {
   @Nullable
   public String getNullable() {
     return null;
+  }
+
+  @Default("my-value")
+  public String getDefaultValue() {
+    return "foo";
   }
 
   @JsonProperty

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -194,6 +194,7 @@ class JsonSchemaTest {
     JSONSchemaProps bar = spec.get("bar");
     Map<String, JSONSchemaProps> barProps = bar.getProperties();
     assertNotNull(barProps);
+    assertTrue(bar.getXKubernetesPreserveUnknownFields());
 
     // you can change everything
     assertEquals("integer", barProps.get("BAZ").getType());

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -15,6 +15,7 @@
  */
 package io.fabric8.crd.generator.v1;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.fabric8.crd.example.annotated.Annotated;
 import io.fabric8.crd.example.basic.Basic;
@@ -32,7 +33,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static io.fabric8.crd.generator.CRDGenerator.YAML_MAPPER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class JsonSchemaTest {
 
@@ -72,7 +79,7 @@ class JsonSchemaTest {
   }
 
   @Test
-  void shouldAugmentPropertiesSchemaFromAnnotations() {
+  void shouldAugmentPropertiesSchemaFromAnnotations() throws JsonProcessingException {
     TypeDef annotated = Types.typeDefFrom(Annotated.class);
     JSONSchemaProps schema = JsonSchema.from(annotated);
     assertNotNull(schema);
@@ -80,7 +87,7 @@ class JsonSchemaTest {
     assertEquals(2, properties.size());
     final JSONSchemaProps specSchema = properties.get("spec");
     Map<String, JSONSchemaProps> spec = specSchema.getProperties();
-    assertEquals(11, spec.size());
+    assertEquals(12, spec.size());
 
     // check descriptions are present
     assertTrue(spec.containsKey("from-field"));
@@ -98,28 +105,39 @@ class JsonSchemaTest {
     assertTrue(spec.containsKey("anEnum"));
 
     final JSONSchemaProps min = spec.get("min");
+    assertNull(min.getDefault());
     assertEquals(-5.0, min.getMinimum());
     assertNull(min.getMaximum());
     assertNull(min.getPattern());
     assertNull(min.getNullable());
 
     final JSONSchemaProps max = spec.get("max");
+    assertNull(max.getDefault());
     assertEquals(5.0, max.getMaximum());
     assertNull(max.getMinimum());
     assertNull(max.getPattern());
     assertNull(max.getNullable());
 
     final JSONSchemaProps pattern = spec.get("singleDigit");
+    assertNull(pattern.getDefault());
     assertEquals("\\b[1-9]\\b", pattern.getPattern());
     assertNull(pattern.getMinimum());
     assertNull(pattern.getMaximum());
     assertNull(pattern.getNullable());
 
     final JSONSchemaProps nullable = spec.get("nullable");
+    assertNull(nullable.getDefault());
     assertTrue(nullable.getNullable());
     assertNull(nullable.getMinimum());
     assertNull(nullable.getMaximum());
     assertNull(nullable.getPattern());
+
+    final JSONSchemaProps defaultValue = spec.get("defaultValue");
+    assertEquals("my-value", YAML_MAPPER.writeValueAsString(defaultValue.getDefault()).trim());
+    assertNull(defaultValue.getNullable());
+    assertNull(defaultValue.getMinimum());
+    assertNull(defaultValue.getMaximum());
+    assertNull(defaultValue.getPattern());
 
     // check required list, should register properties with their modified name if needed
     final List<String> required = specSchema.getRequired();

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -381,19 +381,20 @@ will be generated as:
 
 ## Features cheatsheet
 
-| Annotation | Description |
-|-----------------------------------------------------------|---------------------------------------------------------------------------------------|
-| `com.fasterxml.jackson.annotation.JsonProperty`           | The field is named after the provided value instead of looking up the java field name |
-| `com.fasterxml.jackson.annotation.JsonPropertyDescription`| The provided text is be embedded in the `description` of the field                    |
-| `com.fasterxml.jackson.annotation.JsonIgnore`             | The field is ignored                                                                  |
-| `com.fasterxml.jackson.annotation.JsonAnyGetter`          | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
-| `com.fasterxml.jackson.annotation.JsonAnySetter`          | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
-| `io.fabric8.generator.annotation.Min`                     | The field defines a validation `min`                                                  |
-| `io.fabric8.generator.annotation.Max`                     | The field defines a validation `max`                                                  |
-| `io.fabric8.generator.annotation.Pattern`                 | The field defines a validation `pattern`                                              |
-| `io.fabric8.generator.annotation.Nullable`                | The field is marked as `nullable`                                                     |
-| `io.fabric8.generator.annotation.Required`                | The field is marked as `required`                                                     |
-| `io.fabric8.crd.generator.annotation.SchemaFrom`          | The field type for the generation is the one coming from the annotation               |
-| `io.fabric8.crd.generator.annotation.SchemaSwap`          | Same as SchemaFrom, but can be applied at any point in the class hierarchy            |
+| Annotation                                                   | Description                                                                           |
+|--------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| `com.fasterxml.jackson.annotation.JsonProperty`              | The field is named after the provided value instead of looking up the java field name |
+| `com.fasterxml.jackson.annotation.JsonPropertyDescription`   | The provided text is be embedded in the `description` of the field                    |
+| `com.fasterxml.jackson.annotation.JsonIgnore`                | The field is ignored                                                                  |
+| `io.fabric8.crd.generator.annotation.PreserveUnknownFields`  | The field have `x-kubernetes-preserve-unknown-fields: true` defined                   |
+| `com.fasterxml.jackson.annotation.JsonAnyGetter`             | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
+| `com.fasterxml.jackson.annotation.JsonAnySetter`             | The corresponding object have `x-kubernetes-preserve-unknown-fields: true` defined    |
+| `io.fabric8.generator.annotation.Min`                        | The field defines a validation `min`                                                  |
+| `io.fabric8.generator.annotation.Max`                        | The field defines a validation `max`                                                  |
+| `io.fabric8.generator.annotation.Pattern`                    | The field defines a validation `pattern`                                              |
+| `io.fabric8.generator.annotation.Nullable`                   | The field is marked as `nullable`                                                     |
+| `io.fabric8.generator.annotation.Required`                   | The field is marked as `required`                                                     |
+| `io.fabric8.crd.generator.annotation.SchemaFrom`             | The field type for the generation is the one coming from the annotation               |
+| `io.fabric8.crd.generator.annotation.SchemaSwap`             | Same as SchemaFrom, but can be applied at any point in the class hierarchy            |
 
 A field of type `com.fasterxml.jackson.databind.JsonNode` is encoded as an empty object with `x-kubernetes-preserve-unknown-fields: true` defined.

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -158,6 +158,30 @@ If a field or one of its accessors is annotated with `io.fabric8.generator.annot
 
 ```java
 public class ExampleSpec {
+  @Default("foo")
+  String someValue;
+}
+```
+
+The field will have the `default` property in the generated CRD, such as:
+
+```yaml
+          spec:
+            properties:
+              someValue:
+                default: foo
+                type: string
+            required:
+            - someValue
+            type: object
+```
+
+### io.fabric8.generator.annotation.Min
+
+If a field or one of its accessors is annotated with `io.fabric8.generator.annotation.Min`
+
+```java
+public class ExampleSpec {
   @Min(-1)
   int someValue;
 }

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -357,6 +357,28 @@ Corresponding `x-kubernetes-preserve-unknown-fields: true` will be generated in 
             x-kubernetes-preserve-unknown-fields: true
 ```
 
+You can also annotation a field with @PreserveUnknownFields:
+
+```java
+interface ExampleInterface {}
+
+public class ExampleSpec {
+    @PreserveUnknownFields
+    ExampleInterface someValue;
+}
+```
+
+will be generated as:
+
+```yaml
+          spec:
+            properties:
+              someValue:
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object
+```
+
 ## Features cheatsheet
 
 | Annotation | Description |

--- a/doc/CRD-generator.md
+++ b/doc/CRD-generator.md
@@ -357,7 +357,7 @@ Corresponding `x-kubernetes-preserve-unknown-fields: true` will be generated in 
             x-kubernetes-preserve-unknown-fields: true
 ```
 
-You can also annotation a field with @PreserveUnknownFields:
+You can also annotate a field with `io.fabric8.crd.generator.annotation.PreserveUnknownFields`:
 
 ```java
 interface ExampleInterface {}

--- a/generator-annotations/src/main/java/io/fabric8/generator/annotation/Default.java
+++ b/generator-annotations/src/main/java/io/fabric8/generator/annotation/Default.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/*
+ * Java representation of the `default` field of JSONSchemaProps
+ * https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#jsonschemaprops-v1-apiextensions-k8s-io
+ */
+@Target({ ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Default {
+  String value();
+}


### PR DESCRIPTION
This back ports changes from:
- https://github.com/fabric8io/kubernetes-client/pull/5431
- https://github.com/fabric8io/kubernetes-client/pull/4425
- https://github.com/fabric8io/kubernetes-client/pull/4398

These were a little less clean to pick than the previous annotation support changes, so take a bit more care in review.