### PR TITLE
exclude transients from annotated path detection

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedMultiPropertyPathDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedMultiPropertyPathDetector.java
@@ -59,7 +59,7 @@ public class AnnotatedMultiPropertyPathDetector extends TypedVisitor<TypeDefBuil
 
   private boolean excludePropertyProcessing(Property p) {
     return p.getAnnotations().stream()
-      .anyMatch(ann -> ann.getClassRef().getFullyQualifiedName().equals(ANNOTATION_JSON_IGNORE));
+      .anyMatch(ann -> ann.getClassRef().getFullyQualifiedName().equals(ANNOTATION_JSON_IGNORE)) || p.isTransient();
   }
 
   @Override

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedPropertyPathDetector.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/visitor/AnnotatedPropertyPathDetector.java
@@ -58,12 +58,8 @@ public class AnnotatedPropertyPathDetector extends TypedVisitor<TypeDefBuilder> 
   }
 
   private static boolean excludePropertyProcessing(Property p) {
-    for (AnnotationRef annotation : p.getAnnotations()) {
-      if (annotation.getClassRef().getFullyQualifiedName().equals(ANNOTATION_JSON_IGNORE)) {
-        return true;
-      }
-    }
-    return false;
+    return p.getAnnotations().stream()
+      .anyMatch(ann -> ann.getClassRef().getFullyQualifiedName().equals(ANNOTATION_JSON_IGNORE)) || p.isTransient();
   }
 
   @Override


### PR DESCRIPTION
Much like we did in https://github.com/HubSpot/kubernetes-client/pull/126, we need to ignore transients when visiting properties for annotated path detection for `SpecReplicas`, `StatusReplicas`, and `PrinterColumns`, otherwise we can misidentify the path of the Immutables `initShim`.