### PR TITLE
fix blazar build args env var

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -6,7 +6,7 @@ enabled: true
 env:
   SET_VERSION_OVERRIDE: $GIT_BRANCH-SNAPSHOT
   MAVEN_OPTS: -Xmx4096m
-  MAVEN_ARGS: -DskipTests -am -pl kubernetes-server-mock,kubernetes-model-generator,kubernetes-model-generator/kubernetes-model-apiextensions,kubernetes-client,crd-generator/api,crd-generator/apt,generator-annotations
+  MAVEN_BUILD_ARGS: -DskipTests -am -pl kubernetes-server-mock,kubernetes-model-generator,kubernetes-model-generator/kubernetes-model-apiextensions,kubernetes-client,crd-generator/api,crd-generator/apt,generator-annotations
 
 buildResources:
   cpus: 2


### PR DESCRIPTION
The environment variable used by Blazar for Maven args needs to change to support recent buildpack updates.  This should fix the current build failures.