### PR TITLE
fix x-kubernetes-preserve-unknown-fields mistakenly added to parent object

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -325,7 +325,7 @@ public abstract class AbstractJsonSchema<T, B> {
         continue;
       }
       final T schema = internalFromImpl(name, possiblyRenamedProperty.getTypeRef(), visited, schemaSwaps, parameterMap);
-      if (facade.preserveUnknownFields) {
+      if (facade.isJsonAny) {
         preserveUnknownFields = true;
       }
 
@@ -416,6 +416,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean nullable;
     private boolean required;
     private boolean ignored;
+    private boolean isJsonAny;
     private boolean preserveUnknownFields;
     private String description;
     private TypeRef schemaFrom;
@@ -478,6 +479,8 @@ public abstract class AbstractJsonSchema<T, B> {
             break;
           case ANNOTATION_JSON_ANY_GETTER:
           case ANNOTATION_JSON_ANY_SETTER:
+            isJsonAny = true;
+            break;
           case ANNOTATION_PERSERVE_UNKNOWN_FIELDS:
             preserveUnknownFields = true;
             break;
@@ -518,6 +521,10 @@ public abstract class AbstractJsonSchema<T, B> {
 
     public boolean isIgnored() {
       return ignored;
+    }
+
+    public boolean isJsonAny() {
+      return isJsonAny;
     }
 
     public boolean isPreserveUnknownFields() {
@@ -564,6 +571,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean nullable;
     private boolean required;
     private boolean ignored;
+    private boolean isJsonAny;
     private boolean preserveUnknownFields;
     private final Property original;
     private String nameContributedBy;
@@ -644,6 +652,7 @@ public abstract class AbstractJsonSchema<T, B> {
           ignored = true;
         }
 
+        isJsonAny = p.isJsonAny() || isJsonAny;
         preserveUnknownFields = p.isPreserveUnknownFields() || preserveUnknownFields;
 
         if (p.contributeSchemaFrom()) {

--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -345,7 +345,7 @@ public abstract class AbstractJsonSchema<T, B> {
           facade.pattern,
           facade.nullable,
           facade.required,
-          facade.preserveUnknownFields);
+          facade.preserveUnknownFields || facade.isJsonAny);
 
       addProperty(possiblyRenamedProperty, builder, possiblyUpdatedSchema, options);
     }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
@@ -26,4 +26,6 @@ public class ExtractionSpec {
   @PreserveUnknownFields
   private Foo bar;
 
+  private Qux qux;
+
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Qux.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Qux.java
@@ -1,0 +1,8 @@
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.PreserveUnknownFields;
+
+public class Qux {
+  @PreserveUnknownFields
+  public Foo foo;
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -196,7 +196,7 @@ class JsonSchemaTest {
     assertEquals(2, properties.size());
     final JSONSchemaProps specSchema = properties.get("spec");
     Map<String, JSONSchemaProps> spec = specSchema.getProperties();
-    assertEquals(2, spec.size());
+    assertEquals(3, spec.size());
 
     // check typed SchemaFrom
     JSONSchemaProps foo = spec.get("foo");
@@ -222,6 +222,13 @@ class JsonSchemaTest {
 
     // you can exclude fields
     assertNull(barProps.get("baz"));
+
+    // verify that x-kubernetes-preserve-unknown-fields isn't on parent object when
+    // nested object is annotated with @PreserveUnknownFields
+    JSONSchemaProps qux = spec.get("qux");
+    Map<String, JSONSchemaProps> quxProps = qux.getProperties();
+    assertTrue(quxProps.get("foo").getXKubernetesPreserveUnknownFields());
+    assertNull(qux.getXKubernetesPreserveUnknownFields());
   }
 
   @Test

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -185,6 +185,12 @@ class JsonSchemaTest {
     JSONSchemaProps fooField = spec.get("foo");
 
     assertTrue(fooField.getXKubernetesPreserveUnknownFields());
+
+    Map<String, JSONSchemaProps> fooProperties =  fooField.getProperties();
+    JSONSchemaProps configAsMapField = fooProperties.get("configAsMap");
+
+    assertNotNull(configAsMapField);
+    assertTrue(configAsMapField.getXKubernetesPreserveUnknownFields());
   }
 
   @Test


### PR DESCRIPTION
It seems that `x-kubernetes-preserve-unknown-fields` was pulled up to the parent object when a containing property was annotated with `@JsonAnyX`, which is correct behavior.  The same property-level indicators were reused when `@PreserveUnknownFields` was added as an annotation, which means that any field annotated with that annotation will contain `x-kubernetes-preserve-unknown-fields` as will the parent, which isn't correct behavior.  

This PR disambiguates the two cases, preserving the original behavior for the `@JsonAny` annotations but breaking the parent `x-kubernetes-preserve-unknown-fields` marking if `@PreserveUnknownField` is used.  I've added a test which fails with the original code, but passes after the additions to `AbstractJsonSchema`.
