### PR TITLE
port preserve-unknown-fields-fix from 5.12.2 to 6.13.4 branch

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -362,7 +362,7 @@ public abstract class AbstractJsonSchema<T, B> {
       }
       final T schema = internalFromImpl(name, possiblyRenamedProperty.getTypeRef(), visited, schemaSwaps, parameterMap);
       visited = savedVisited;
-      if (facade.preserveUnknownFields) {
+      if (facade.isJsonAny) {
         preserveUnknownFields = true;
       }
 
@@ -383,7 +383,7 @@ public abstract class AbstractJsonSchema<T, B> {
           facade.validationRules,
           facade.nullable,
           facade.required,
-          facade.preserveUnknownFields);
+          facade.preserveUnknownFields || facade.isJsonAny);
 
       addProperty(possiblyRenamedProperty, builder, possiblyUpdatedSchema, options);
     }
@@ -466,6 +466,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean nullable;
     private boolean required;
     private boolean ignored;
+    private boolean isJsonAny;
     private boolean preserveUnknownFields;
     private String description;
     private TypeRef schemaFrom;
@@ -531,6 +532,8 @@ public abstract class AbstractJsonSchema<T, B> {
             break;
           case ANNOTATION_JSON_ANY_GETTER:
           case ANNOTATION_JSON_ANY_SETTER:
+            isJsonAny = true;
+            break;
           case ANNOTATION_PERSERVE_UNKNOWN_FIELDS:
             preserveUnknownFields = true;
             break;
@@ -581,6 +584,10 @@ public abstract class AbstractJsonSchema<T, B> {
       return ignored;
     }
 
+    public boolean isJsonAny() {
+      return isJsonAny;
+    }
+
     public boolean isPreserveUnknownFields() {
       return preserveUnknownFields;
     }
@@ -623,6 +630,7 @@ public abstract class AbstractJsonSchema<T, B> {
     private boolean nullable;
     private boolean required;
     private boolean ignored;
+    private boolean isJsonAny;
     private boolean preserveUnknownFields;
     private final Property original;
     private String nameContributedBy;
@@ -695,6 +703,7 @@ public abstract class AbstractJsonSchema<T, B> {
           ignored = true;
         }
 
+        isJsonAny = p.isJsonAny() || isJsonAny;
         preserveUnknownFields = p.isPreserveUnknownFields() || preserveUnknownFields;
 
         if (p.contributeSchemaFrom()) {

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/ExtractionSpec.java
@@ -26,4 +26,6 @@ public class ExtractionSpec {
   @PreserveUnknownFields
   private Foo bar;
 
+  private Qux qux;
+
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Qux.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/extraction/Qux.java
@@ -1,0 +1,8 @@
+package io.fabric8.crd.example.extraction;
+
+import io.fabric8.crd.generator.annotation.PreserveUnknownFields;
+
+public class Qux {
+  @PreserveUnknownFields
+  public Foo foo;
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -205,6 +205,12 @@ class JsonSchemaTest {
 
     assertEquals("object", fooField.getType());
     assertTrue(fooField.getXKubernetesPreserveUnknownFields());
+
+    Map<String, JSONSchemaProps> fooProperties =  fooField.getProperties();
+    JSONSchemaProps configAsMapField = fooProperties.get("configAsMap");
+
+    assertNotNull(configAsMapField);
+    assertTrue(configAsMapField.getXKubernetesPreserveUnknownFields());
   }
 
   @Test
@@ -214,7 +220,7 @@ class JsonSchemaTest {
     assertNotNull(schema);
     Map<String, JSONSchemaProps> properties = assertSchemaHasNumberOfProperties(schema, 2);
     final JSONSchemaProps specSchema = properties.get("spec");
-    Map<String, JSONSchemaProps> spec = assertSchemaHasNumberOfProperties(specSchema, 2);
+    Map<String, JSONSchemaProps> spec = assertSchemaHasNumberOfProperties(specSchema, 3);
 
     // check typed SchemaFrom
     JSONSchemaProps foo = spec.get("foo");
@@ -240,6 +246,13 @@ class JsonSchemaTest {
 
     // you can exclude fields
     assertNull(barProps.get("baz"));
+
+    // verify that x-kubernetes-preserve-unknown-fields isn't on parent object when
+    // nested object is annotated with @PreserveUnknownFields
+    JSONSchemaProps qux = spec.get("qux");
+    Map<String, JSONSchemaProps> quxProps = qux.getProperties();
+    assertTrue(quxProps.get("foo").getXKubernetesPreserveUnknownFields());
+    assertNull(qux.getXKubernetesPreserveUnknownFields());
   }
 
   @Test


### PR DESCRIPTION
Ports fix from https://github.com/HubSpot/kubernetes-client/pull/134 to the `6.13.4-hubspot` branch.