### PR TITLE
fix property case-handling during CRD gen

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -517,7 +517,7 @@ public abstract class AbstractJsonSchema<T, B> {
             break;
           case ANNOTATION_JSON_PROPERTY:
             final String nameFromAnnotation = (String) a.getParameters().get(VALUE);
-            if (!Strings.isNullOrEmpty(nameFromAnnotation) && !propertyName.equals(nameFromAnnotation)) {
+            if (!Strings.isNullOrEmpty(nameFromAnnotation)) {
               renamedTo = nameFromAnnotation;
             }
             break;
@@ -711,11 +711,37 @@ public abstract class AbstractJsonSchema<T, B> {
         }
       });
 
+      String caseCorrectedPropertyName = getCaseCorrectedPropertyName();
+      if(renamedTo == null && !original.getName().equals(caseCorrectedPropertyName) ) {
+        renamedTo = caseCorrectedPropertyName;
+      }
+
       TypeRef typeRef = schemaFrom != null ? schemaFrom : parameterMap.exchange(original.getTypeRef());
       String finalName = renamedTo != null ? renamedTo : original.getName();
 
       return new Property(original.getAnnotations(), typeRef, finalName,
           original.getComments(), false, false, original.getModifiers(), original.getAttributes());
+    }
+
+    private  String getCaseCorrectedPropertyName() {
+      String capitalizedOriginalPropertyName = original.getNameCapitalized();
+      StringBuilder newPropertyNameBuilder = new StringBuilder();
+
+      int index;
+      for (index = 0;index<capitalizedOriginalPropertyName.length();index++) {
+        char charAtIndex = capitalizedOriginalPropertyName.charAt(index);
+        if(Character.isUpperCase(charAtIndex)) {
+          newPropertyNameBuilder.append(Character.toLowerCase(charAtIndex));
+        } else {
+          break;
+        }
+      }
+
+      if(index<capitalizedOriginalPropertyName.length()) {
+        newPropertyNameBuilder.append(capitalizedOriginalPropertyName.substring(index));
+      }
+
+      return newPropertyNameBuilder.toString();
     }
   }
 

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/serialization/AnnotatedSerializationExample.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/serialization/AnnotatedSerializationExample.java
@@ -1,0 +1,12 @@
+package io.fabric8.crd.example.serialization;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class AnnotatedSerializationExample {
+  String fOoBar;
+
+  @JsonProperty("fOoBar")
+  public String getFOoBar() {
+    return fOoBar;
+  }
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/serialization/SerializationExample.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/serialization/SerializationExample.java
@@ -1,0 +1,7 @@
+package io.fabric8.crd.example.serialization;
+
+public class SerializationExample {
+  String uRL;
+  String fOoBar;
+  String normalCase;
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -31,6 +31,8 @@ import io.fabric8.crd.example.extraction.NestedSchemaSwap;
 import io.fabric8.crd.example.generic.ResourceWithGeneric;
 import io.fabric8.crd.example.json.ContainingJson;
 import io.fabric8.crd.example.person.Person;
+import io.fabric8.crd.example.serialization.AnnotatedSerializationExample;
+import io.fabric8.crd.example.serialization.SerializationExample;
 import io.fabric8.crd.generator.utils.Types;
 import io.fabric8.kubernetes.api.model.AnyType;
 import io.fabric8.kubernetes.api.model.apiextensions.v1.JSONSchemaProps;
@@ -444,5 +446,31 @@ class JsonSchemaTest {
     JSONSchemaProps corgeItemsProps = corgeItems.getSchema();
     assertNotNull(corgeItemsProps);
     assertEquals("string", corgeItemsProps.getType());
+  }
+
+  @Test
+  void shouldProduceDeserializableNames() {
+    TypeDef serializationExample = Types.typeDefFrom(SerializationExample.class);
+    JSONSchemaProps schema = JsonSchema.from(serializationExample);
+    assertNotNull(schema);
+
+    Map<String, JSONSchemaProps> properties = schema.getProperties();
+    assertEquals(3, properties.size());
+
+    assertTrue(properties.containsKey("url"));
+    assertTrue(properties.containsKey("fooBar"));
+    assertTrue(properties.containsKey("normalCase"));
+  }
+
+  @Test
+  void itShouldNotChangeAnnotatedNames() {
+    TypeDef annotatedSerializationExample = Types.typeDefFrom(AnnotatedSerializationExample.class);
+    JSONSchemaProps schema = JsonSchema.from(annotatedSerializationExample);
+    assertNotNull(schema);
+
+    Map<String, JSONSchemaProps> properties = schema.getProperties();
+    assertEquals(1, properties.size());
+
+    assertTrue(properties.containsKey("fOoBar"));
   }
 }


### PR DESCRIPTION
We've noticed that Immutables doesn't follow the same case-conventions as Jackson in cases where the getter is something like `getHBaseImage()`.  In that case, Immutables makes the field on the POJO `hBaseImage` and therefore that is the field name in the generated CRDs.  Jackson expects the field name in that case to be `hbaseImage`, and therefore there's a deserialization error thrown with the field is required on the POJO.

This PR makes sure the field names follow the Jackson case-conventions unless overridden by the `JsonProperty` annotation.