### PR TITLE
detect accessors with the same name as field in CRD generation

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -656,6 +656,10 @@ public abstract class AbstractJsonSchema<T, B> {
       if (method != null) {
         propertyOrAccessors.add(PropertyOrAccessor.fromMethod(method, name));
       }
+      method = potentialAccessors.get(name);
+      if (method != null) {
+        propertyOrAccessors.add(PropertyOrAccessor.fromMethod(method, name));
+      }
       schemaFrom = schemaSwap;
       defaultValue = null;
       min = null;


### PR DESCRIPTION
When Immutable interfaces have a getter name that, when converted to a field name, would conflict with a protected keyword, then the field just takes the same name as the getter.  When this happens, CRD generation doesn't match the field with the getter and therefore annotations that may be on that getter are ignored.

The specific case we're trying to solve has a getter in the interface named `getFinal()`.  Currently CRD generation ends up making the field `getFinal` on the YAML definition.  If we try to modify that behavior with the `@JsonProperty` annotation, then it gets ignored since the annotation ends up on the getter in the generated Immutable class, and CRD generation can't do the matching.