### PR TITLE
add a Rename annotation separate from JsonProperty

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractJsonSchema.java
@@ -129,6 +129,7 @@ public abstract class AbstractJsonSchema<T, B> {
   public static final String ANNOTATION_SCHEMA_SWAPS = "io.fabric8.crd.generator.annotation.SchemaSwaps";
   public static final String ANNOTATION_VALIDATION_RULE = "io.fabric8.generator.annotation.ValidationRule";
   public static final String ANNOTATION_VALIDATION_RULES = "io.fabric8.generator.annotation.ValidationRules";
+  public static final String ANNOTATION_RENAME = "io.fabric8.crd.generator.annotation.Rename";
 
   public static final String JSON_NODE_TYPE = "com.fasterxml.jackson.databind.JsonNode";
   public static final String ANY_TYPE = "io.fabric8.kubernetes.api.model.AnyType";
@@ -516,6 +517,7 @@ public abstract class AbstractJsonSchema<T, B> {
             }
             break;
           case ANNOTATION_JSON_PROPERTY:
+          case ANNOTATION_RENAME:
             final String nameFromAnnotation = (String) a.getParameters().get(VALUE);
             if (!Strings.isNullOrEmpty(nameFromAnnotation)) {
               renamedTo = nameFromAnnotation;

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/annotated/AnnotatedSpec.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.fabric8.crd.generator.annotation.Rename;
 import io.fabric8.generator.annotation.Default;
 import io.fabric8.generator.annotation.Max;
 import io.fabric8.generator.annotation.Min;
@@ -180,4 +182,7 @@ public class AnnotatedSpec {
   public enum AnotherEnum {
     ONE
   }
+
+  @Rename("renamedField")
+  private String fieldToRename;
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/v1/JsonSchemaTest.java
@@ -109,7 +109,7 @@ class JsonSchemaTest {
     assertNotNull(schema);
     Map<String, JSONSchemaProps> properties = assertSchemaHasNumberOfProperties(schema, 2);
     final JSONSchemaProps specSchema = properties.get("spec");
-    Map<String, JSONSchemaProps> spec = assertSchemaHasNumberOfProperties(specSchema, 20);
+    Map<String, JSONSchemaProps> spec = assertSchemaHasNumberOfProperties(specSchema, 21);
 
     // check descriptions are present
     assertTrue(spec.containsKey("from-field"));
@@ -178,6 +178,10 @@ class JsonSchemaTest {
     assertNull(kubernetesValidationsRepeatedRules.get(1).getMessage());
     assertNull(kubernetesValidationsRepeatedRules.get(1).getMessageExpression());
     assertNull(kubernetesValidationsRepeatedRules.get(1).getOptionalOldSelf());
+
+    // check descriptions are present
+    assertTrue(spec.containsKey("renamedField"));
+    assertFalse(spec.containsKey("fieldToRename"));
   }
 
   @Test

--- a/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/Rename.java
+++ b/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/Rename.java
@@ -1,0 +1,12 @@
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.FIELD, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Rename {
+  String value();
+}


### PR DESCRIPTION
We've struggled to get the `@JsonPropery` annotation working to rename fields when also using Immutables.  This PR creates a work around by adding another annotation, `@Rename`, that can be used to rename fields as it seems our difficulties are confined to `@JsonProperty`.

Relates to https://git.hubteam.com/HubSpot/kube-operators/issues/8724