### PR TITLE
Add `createOrUpdateWithFieldManager` method to set field manager without using server-side apply

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -38,9 +38,10 @@ public interface CreateOrReplaceable<T> extends Replaceable<T> {
    * This is a variation of createOrReplace that explicitly sets the fieldManager
    * query parameter when communicating with the Kubernetes API.
    *
+   * @param fieldManager the field manager to use
    * @return created item returned in kubernetes api response
    */
-  T createOrReplaceWithFieldManager();
+  T createOrReplaceWithFieldManager(String fieldManager);
 
   /**
    * Creates an item

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -31,6 +31,16 @@ public interface CreateOrReplaceable<T> extends Replaceable<T> {
    */
   @Deprecated
   T createOrReplace();
+  
+  /**
+   * Creates a provided resource in a Kubernetes Cluster with a specific field manager. 
+   * If creation fails with a HTTP_CONFLICT, it tries to replace resource.
+   * This is a variation of createOrReplace that explicitly sets the fieldManager
+   * query parameter when communicating with the Kubernetes API.
+   *
+   * @return created item returned in kubernetes api response
+   */
+  T createOrReplaceWithFieldManager();
 
   /**
    * Creates an item

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/dsl/CreateOrReplaceable.java
@@ -33,10 +33,7 @@ public interface CreateOrReplaceable<T> extends Replaceable<T> {
   T createOrReplace();
   
   /**
-   * Creates a provided resource in a Kubernetes Cluster with a specific field manager. 
-   * If creation fails with a HTTP_CONFLICT, it tries to replace resource.
-   * This is a variation of createOrReplace that explicitly sets the fieldManager
-   * query parameter when communicating with the Kubernetes API.
+   * Creates a provided resource in a Kubernetes Cluster with a specific field manager.
    *
    * @param fieldManager the field manager to use
    * @return created item returned in kubernetes api response

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -125,8 +125,8 @@ public class ResourceAdapter<T> implements Resource<T> {
   }
   
   @Override
-  public T createOrReplaceWithFieldManager() {
-    return resource.createOrReplaceWithFieldManager();
+  public T createOrReplaceWithFieldManager(String fieldManager) {
+    return resource.createOrReplaceWithFieldManager(fieldManager);
   }
 
   @Override

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/extension/ResourceAdapter.java
@@ -123,6 +123,11 @@ public class ResourceAdapter<T> implements Resource<T> {
   public T createOrReplace() {
     return resource.createOrReplace();
   }
+  
+  @Override
+  public T createOrReplaceWithFieldManager() {
+    return resource.createOrReplaceWithFieldManager();
+  }
 
   @Override
   public T editStatus(UnaryOperator<T> function) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -320,24 +320,19 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
    * @return The created or replaced resource
    */
   public final T createOrReplaceWithFieldManager() {
+    System.out.println("Client dep version: 1");
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }
-    /*
-    // Define custom create/replace functions that add the field manager parameter to the URL
+
     UnaryOperator<T> createWithFieldManager = resourceItem -> {
       try {
+        // We do this everywhere else
         updateApiVersion(resourceItem);
-        
-        // For creates, we set resourceVersion to null (this is done in CreateOrReplaceHelper too)
-        // This is a safety precaution, but the actual implementation in CreateOrReplaceHelper
-        // explicitly sets it to null before calling createTask
-        
-        // Create URL with the field manager parameter
+
+        // Set the (for now) hardcoded field manager query param
         URL resourceUrl = getResourceURLForWriteOperation(
             getResourceUrl(checkNamespace(resourceItem), null));
-
-        // Add field manager parameter to the URL
         String url = resourceUrl.toString();
         if (url.contains("?")) {
           url += "&fieldManager=mbc-foo-bar-field-manager";
@@ -347,7 +342,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         resourceUrl = new URL(url);
 
         System.out.println("mbc: Attempting CREATE with url: " + url);
-        // Manually construct and send the request with the modified URL
+
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
             .post(JSON, getKubernetesSerialization().asJson(resourceItem))
             .url(resourceUrl);
@@ -358,21 +353,32 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       }
     };
 
-    // In CreateOrReplaceHelper, it uses the original resource version for replace operations
-    // The pattern followed by CreateOrReplaceHelper is to maintain the original resource version
-    // that the item had before attempting the create, not to fetch a new one from the server.
+    // Alternative to HasMetadataOperation::replace as called in createOrReplace
     UnaryOperator<T> replaceWithFieldManager = resourceItem -> {
       try {
         updateApiVersion(resourceItem);
-        // Important: No need to fetch resource version from server
-        // CreateOrReplaceHelper uses the original resource version saved earlier
-        // Resource version is set by CreateOrReplaceHelper before calling replaceTask
-        
-        // Create URL with the field manager parameter
+
+        // Borrowed from HasMetadataOperation::handleReplace
+        // TODO: item vs resourceItem?
+        String existingResourceVersion = KubernetesResourceUtil.getResourceVersion(item);
+        String fixedResourceVersion = getResourceVersion();
+        final String resourceVersion;
+        if (fixedResourceVersion != null) {
+          resourceVersion = fixedResourceVersion;
+        } else if (existingResourceVersion != null) {
+          // if a resourceVersion is already there, use it
+          resourceVersion = existingResourceVersion;
+          System.out.println("mbc: Using existingResourceVersion: " + resourceVersion);
+        } else {
+          T got = requireFromServer();
+          resourceVersion = KubernetesResourceUtil.getResourceVersion(got);
+        }
+        System.out.println("mbc: Using resource version" + resourceVersion);
+        resourceItem.getMetadata().setResourceVersion(resourceVersion);
+
+        // Set fieldManager...
         URL resourceUrl = getResourceURLForWriteOperation(
             getResourceUrl(checkNamespace(resourceItem), checkName(resourceItem)));
-
-        // Add field manager parameter to the URL
         String url = resourceUrl.toString();
         if (url.contains("?")) {
           url += "&fieldManager=mbc-foo-bar-field-manager";
@@ -382,7 +388,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         resourceUrl = new URL(url);
 
         System.out.println("mbc: Attempting REPLACE with url: " + url);
-        // Manually construct and send the request with the modified URL
+
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
             .put(JSON, getKubernetesSerialization().asJson(resourceItem))
             .url(resourceUrl);
@@ -392,35 +398,16 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         throw KubernetesClientException.launderThrowable(forOperationType("replace"), e);
       }
     };
-     */
 
     R resource = resource(item);
 
-    /*
     CreateOrReplaceHelper<T> createOrReplaceHelper = new CreateOrReplaceHelper<>(
         createWithFieldManager,
         replaceWithFieldManager,
         m -> resource.waitUntilCondition(Objects::nonNull, 1, TimeUnit.SECONDS),
         m -> resource.fromServer().get(), this.getKubernetesSerialization());
-     */
-    System.out.println("mbc: Using old create or replace helper but setting field manager");
-    String oldFieldManager = context.fieldManager;
-    System.out.println("mbc: old field manager: " + oldFieldManager);
-    context.fieldManager = "mbc-field-manager-override-hack";
-    CreateOrReplaceHelper<T> createOrReplaceHelper = new CreateOrReplaceHelper<>(
-      resource::create,
-      resource::replace,
-      m -> resource.waitUntilCondition(Objects::nonNull, 1, TimeUnit.SECONDS),
-      m -> resource.fromServer().get(), this.getKubernetesSerialization());
 
-    T ret = createOrReplaceHelper.createOrReplace(item);
-
-    // Reset field manager
-    // TODO: Is this threadsafe? Necessary at all? Or do we instantiate a new BaseOperation every time a command is
-    // TOOD: run (which means we don't even need to reset it here)?
-    context.fieldManager = oldFieldManager;
-
-    return ret;
+    return createOrReplaceHelper.createOrReplace(item);
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -352,6 +352,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         }
         resourceUrl = new URL(url);
 
+        System.out.println("mbc: Attempting CREATE with url: " + url);
         // Manually construct and send the request with the modified URL
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
             .post(JSON, getKubernetesSerialization().asJson(resourceItem))
@@ -386,6 +387,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         }
         resourceUrl = new URL(url);
 
+        System.out.println("mbc: Attempting REPLACE with url: " + url);
         // Manually construct and send the request with the modified URL
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
             .put(JSON, getKubernetesSerialization().asJson(resourceItem))

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -317,9 +317,10 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
   /**
    * Creates or replaces the resource with a custom field manager.
    *
+   * @param fieldManager The field manager to use for the operation
    * @return The created or replaced resource
    */
-  public final T createOrReplaceWithFieldManager() {
+  public final T createOrReplaceWithFieldManager(String fieldManager) {
     System.out.println("Client dep version: 1");
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
@@ -330,14 +331,14 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         // We do this everywhere else
         updateApiVersion(resourceItem);
 
-        // Set the (for now) hardcoded field manager query param
+        // Set the field manager query param
         URL resourceUrl = getResourceURLForWriteOperation(
             getResourceUrl(checkNamespace(resourceItem), null));
         String url = resourceUrl.toString();
         if (url.contains("?")) {
-          url += "&fieldManager=mbc-foo-bar-field-manager";
+          url += "&fieldManager=" + fieldManager;
         } else {
-          url += "?fieldManager=mbc-foo-bar-field-manager";
+          url += "?fieldManager=" + fieldManager;
         }
         resourceUrl = new URL(url);
 
@@ -381,9 +382,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
             getResourceUrl(checkNamespace(resourceItem), checkName(resourceItem)));
         String url = resourceUrl.toString();
         if (url.contains("?")) {
-          url += "&fieldManager=mbc-foo-bar-field-manager";
+          url += "&fieldManager=" + fieldManager;
         } else {
-          url += "?fieldManager=mbc-foo-bar-field-manager";
+          url += "?fieldManager=" + fieldManager;
         }
         resourceUrl = new URL(url);
 
@@ -409,6 +410,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
     return createOrReplaceHelper.createOrReplace(item);
   }
+  
 
   @Override
   public T createOr(Function<NonDeletingOperation<T>, T> conflictAction) {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -316,8 +316,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   /**
    * Creates or replaces the resource with a custom field manager.
-   * This is an extension of the createOrReplace method that explicitly sets
-   * a field manager in the request to the Kubernetes API.
    *
    * @return The created or replaced resource
    */
@@ -325,10 +323,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }
-
-    // Create a customized version of the resource
-    R resource = resource(item);
-
+    /*
     // Define custom create/replace functions that add the field manager parameter to the URL
     UnaryOperator<T> createWithFieldManager = resourceItem -> {
       try {
@@ -397,17 +392,35 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         throw KubernetesClientException.launderThrowable(forOperationType("replace"), e);
       }
     };
+     */
 
-    // Create the helper with our custom operations
-    // The helper handles saving and restoring the resource version
-    // See CreateOrReplaceHelper.createOrReplace() implementation
+    R resource = resource(item);
+
+    /*
     CreateOrReplaceHelper<T> createOrReplaceHelper = new CreateOrReplaceHelper<>(
         createWithFieldManager,
         replaceWithFieldManager,
         m -> resource.waitUntilCondition(Objects::nonNull, 1, TimeUnit.SECONDS),
         m -> resource.fromServer().get(), this.getKubernetesSerialization());
+     */
+    System.out.println("mbc: Using old create or replace helper but setting field manager");
+    String oldFieldManager = context.fieldManager;
+    System.out.println("mbc: old field manager: " + oldFieldManager);
+    context.fieldManager = "mbc-field-manager-override-hack";
+    CreateOrReplaceHelper<T> createOrReplaceHelper = new CreateOrReplaceHelper<>(
+      resource::create,
+      resource::replace,
+      m -> resource.waitUntilCondition(Objects::nonNull, 1, TimeUnit.SECONDS),
+      m -> resource.fromServer().get(), this.getKubernetesSerialization());
 
-    return createOrReplaceHelper.createOrReplace(item);
+    T ret = createOrReplaceHelper.createOrReplace(item);
+
+    // Reset field manager
+    // TODO: Is this threadsafe? Necessary at all? Or do we instantiate a new BaseOperation every time a command is
+    // TOOD: run (which means we don't even need to reset it here)?
+    context.fieldManager = oldFieldManager;
+
+    return ret;
   }
 
   @Override

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -322,7 +322,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
    * @return The created or replaced resource
    */
   public final T createOrReplaceWithFieldManager() {
-    System.out.println("Attempting to create or replace with a custom fieldManager");
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }
@@ -334,12 +333,15 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     UnaryOperator<T> createWithFieldManager = resourceItem -> {
       try {
         // Clone the item to avoid modifying the original
-        T itemToCreate = this.getKubernetesSerialization().clone(resourceItem);
-        updateApiVersion(itemToCreate);
-
+        updateApiVersion(resourceItem);
+        
+        // For creates, we set resourceVersion to null (this is done in CreateOrReplaceHelper too)
+        // This is a safety precaution, but the actual implementation in CreateOrReplaceHelper
+        // explicitly sets it to null before calling createTask
+        
         // Create URL with the field manager parameter
         URL resourceUrl = getResourceURLForWriteOperation(
-            getResourceUrl(checkNamespace(itemToCreate), null));
+            getResourceUrl(checkNamespace(resourceItem), null));
 
         // Add field manager parameter to the URL
         String url = resourceUrl.toString();
@@ -352,7 +354,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
         // Manually construct and send the request with the modified URL
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
-            .post(JSON, getKubernetesSerialization().asJson(itemToCreate))
+            .post(JSON, getKubernetesSerialization().asJson(resourceItem))
             .url(resourceUrl);
 
         return handleResponse(requestBuilder, getType());
@@ -361,15 +363,19 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       }
     };
 
+    // In CreateOrReplaceHelper, it uses the original resource version for replace operations
+    // The pattern followed by CreateOrReplaceHelper is to maintain the original resource version
+    // that the item had before attempting the create, not to fetch a new one from the server.
     UnaryOperator<T> replaceWithFieldManager = resourceItem -> {
       try {
-        // Clone the item to avoid modifying the original
-        T itemToReplace = this.getKubernetesSerialization().clone(resourceItem);
-        updateApiVersion(itemToReplace);
-
+        updateApiVersion(resourceItem);
+        // Important: No need to fetch resource version from server
+        // CreateOrReplaceHelper uses the original resource version saved earlier
+        // Resource version is set by CreateOrReplaceHelper before calling replaceTask
+        
         // Create URL with the field manager parameter
         URL resourceUrl = getResourceURLForWriteOperation(
-            getResourceUrl(checkNamespace(itemToReplace), checkName(itemToReplace)));
+            getResourceUrl(checkNamespace(resourceItem), checkName(resourceItem)));
 
         // Add field manager parameter to the URL
         String url = resourceUrl.toString();
@@ -382,7 +388,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
         // Manually construct and send the request with the modified URL
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
-            .put(JSON, getKubernetesSerialization().asJson(itemToReplace))
+            .put(JSON, getKubernetesSerialization().asJson(resourceItem))
             .url(resourceUrl);
 
         return handleResponse(requestBuilder, getType());
@@ -391,6 +397,9 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
       }
     };
 
+    // Create the helper with our custom operations
+    // The helper handles saving and restoring the resource version
+    // See CreateOrReplaceHelper.createOrReplace() implementation
     CreateOrReplaceHelper<T> createOrReplaceHelper = new CreateOrReplaceHelper<>(
         createWithFieldManager,
         replaceWithFieldManager,

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -300,6 +300,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public final T createOrReplace() {
+    System.out.println("Hello from the createOrReplace method, you depending on a test branch.");
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -321,7 +321,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
    * @return The created or replaced resource
    */
   public final T createOrReplaceWithFieldManager(String fieldManager) {
-    System.out.println("Client dep version: 1");
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }
@@ -342,8 +341,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         }
         resourceUrl = new URL(url);
 
-        System.out.println("mbc: Attempting CREATE with url: " + url);
-
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
             .post(JSON, getKubernetesSerialization().asJson(resourceItem))
             .url(resourceUrl);
@@ -360,7 +357,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         updateApiVersion(resourceItem);
 
         // Borrowed from HasMetadataOperation::handleReplace
-        // TODO: item vs resourceItem?
         String existingResourceVersion = KubernetesResourceUtil.getResourceVersion(item);
         String fixedResourceVersion = getResourceVersion();
         final String resourceVersion;
@@ -369,12 +365,10 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
         } else if (existingResourceVersion != null) {
           // if a resourceVersion is already there, use it
           resourceVersion = existingResourceVersion;
-          System.out.println("mbc: Using existingResourceVersion: " + resourceVersion);
         } else {
           T got = requireFromServer();
           resourceVersion = KubernetesResourceUtil.getResourceVersion(got);
         }
-        System.out.println("mbc: Using resource version" + resourceVersion);
         resourceItem.getMetadata().setResourceVersion(resourceVersion);
 
         // Set fieldManager...
@@ -387,8 +381,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
           url += "?fieldManager=" + fieldManager;
         }
         resourceUrl = new URL(url);
-
-        System.out.println("mbc: Attempting REPLACE with url: " + url);
 
         HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
             .put(JSON, getKubernetesSerialization().asJson(resourceItem))

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -300,7 +300,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public final T createOrReplace() {
-    System.out.println("Hello from the createOrReplace method, you depending on a test branch.");
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }
@@ -309,6 +308,92 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     CreateOrReplaceHelper<T> createOrReplaceHelper = new CreateOrReplaceHelper<>(
         resource::create,
         resource::replace,
+        m -> resource.waitUntilCondition(Objects::nonNull, 1, TimeUnit.SECONDS),
+        m -> resource.fromServer().get(), this.getKubernetesSerialization());
+
+    return createOrReplaceHelper.createOrReplace(item);
+  }
+
+  /**
+   * Creates or replaces the resource with a custom field manager.
+   * This is an extension of the createOrReplace method that explicitly sets
+   * a field manager in the request to the Kubernetes API.
+   *
+   * @return The created or replaced resource
+   */
+  public final T createOrReplaceWithFieldManager() {
+    System.out.println("Attempting to create or replace with a custom fieldManager");
+    if (item == null) {
+      throw new IllegalArgumentException("Nothing to create.");
+    }
+
+    // Create a customized version of the resource
+    R resource = resource(item);
+
+    // Define custom create/replace functions that add the field manager parameter to the URL
+    UnaryOperator<T> createWithFieldManager = resourceItem -> {
+      try {
+        // Clone the item to avoid modifying the original
+        T itemToCreate = this.getKubernetesSerialization().clone(resourceItem);
+        updateApiVersion(itemToCreate);
+
+        // Create URL with the field manager parameter
+        URL resourceUrl = getResourceURLForWriteOperation(
+            getResourceUrl(checkNamespace(itemToCreate), null));
+
+        // Add field manager parameter to the URL
+        String url = resourceUrl.toString();
+        if (url.contains("?")) {
+          url += "&fieldManager=mbc-foo-bar-field-manager";
+        } else {
+          url += "?fieldManager=mbc-foo-bar-field-manager";
+        }
+        resourceUrl = new URL(url);
+
+        // Manually construct and send the request with the modified URL
+        HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
+            .post(JSON, getKubernetesSerialization().asJson(itemToCreate))
+            .url(resourceUrl);
+
+        return handleResponse(requestBuilder, getType());
+      } catch (IOException e) {
+        throw KubernetesClientException.launderThrowable(forOperationType("create"), e);
+      }
+    };
+
+    UnaryOperator<T> replaceWithFieldManager = resourceItem -> {
+      try {
+        // Clone the item to avoid modifying the original
+        T itemToReplace = this.getKubernetesSerialization().clone(resourceItem);
+        updateApiVersion(itemToReplace);
+
+        // Create URL with the field manager parameter
+        URL resourceUrl = getResourceURLForWriteOperation(
+            getResourceUrl(checkNamespace(itemToReplace), checkName(itemToReplace)));
+
+        // Add field manager parameter to the URL
+        String url = resourceUrl.toString();
+        if (url.contains("?")) {
+          url += "&fieldManager=mbc-foo-bar-field-manager";
+        } else {
+          url += "?fieldManager=mbc-foo-bar-field-manager";
+        }
+        resourceUrl = new URL(url);
+
+        // Manually construct and send the request with the modified URL
+        HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
+            .put(JSON, getKubernetesSerialization().asJson(itemToReplace))
+            .url(resourceUrl);
+
+        return handleResponse(requestBuilder, getType());
+      } catch (IOException e) {
+        throw KubernetesClientException.launderThrowable(forOperationType("replace"), e);
+      }
+    };
+
+    CreateOrReplaceHelper<T> createOrReplaceHelper = new CreateOrReplaceHelper<>(
+        createWithFieldManager,
+        replaceWithFieldManager,
         m -> resource.waitUntilCondition(Objects::nonNull, 1, TimeUnit.SECONDS),
         m -> resource.fromServer().get(), this.getKubernetesSerialization());
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -332,7 +332,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
     // Define custom create/replace functions that add the field manager parameter to the URL
     UnaryOperator<T> createWithFieldManager = resourceItem -> {
       try {
-        // Clone the item to avoid modifying the original
         updateApiVersion(resourceItem);
         
         // For creates, we set resourceVersion to null (this is done in CreateOrReplaceHelper too)

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
@@ -97,7 +97,6 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
 
   @Override
   public T replace() {
-    System.out.println("mbc: in HasMetadataOperation::replace");
     return handleReplace(getItem());
   }
 
@@ -151,9 +150,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
    * base replace operation, which is effectively a forced update with retries
    */
   protected T handleReplace(T item) {
-    System.out.println("mbc: In handle replace");
     String fixedResourceVersion = getResourceVersion();
-    System.out.println("mbc: Got fixed resource version " + fixedResourceVersion);
     Exception caught = null;
     int maxTries = 10;
     item = clone(item);
@@ -168,7 +165,6 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
       }
     }
     String existingResourceVersion = KubernetesResourceUtil.getResourceVersion(item);
-    System.out.println("mbc: Got existing resource version " + existingResourceVersion);
     for (int i = 0; i < maxTries; i++) {
       try {
         final String resourceVersion;
@@ -185,7 +181,6 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
         final UnaryOperator<T> visitor = resource -> {
           try {
             resource.getMetadata().setResourceVersion(resourceVersion);
-            System.out.println("mbc: Attempting update with resource version: " + resourceVersion);
             return handleUpdate(resource);
           } catch (Exception e) {
             throw KubernetesClientException.launderThrowable(forOperationType(REPLACE_OPERATION), e);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
@@ -150,7 +150,9 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
    * base replace operation, which is effectively a forced update with retries
    */
   protected T handleReplace(T item) {
+    System.out.println("mbc: In handle replace");
     String fixedResourceVersion = getResourceVersion();
+    System.out.println("mbc: Got fixed resource version " + fixedResourceVersion);
     Exception caught = null;
     int maxTries = 10;
     item = clone(item);
@@ -165,6 +167,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
       }
     }
     String existingResourceVersion = KubernetesResourceUtil.getResourceVersion(item);
+    System.out.println("mbc: Got existing resource version " + existingResourceVersion);
     for (int i = 0; i < maxTries; i++) {
       try {
         final String resourceVersion;
@@ -181,6 +184,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
         final UnaryOperator<T> visitor = resource -> {
           try {
             resource.getMetadata().setResourceVersion(resourceVersion);
+            System.out.println("mbc: Attempting update with resource version: " + resourceVersion);
             return handleUpdate(resource);
           } catch (Exception e) {
             throw KubernetesClientException.launderThrowable(forOperationType(REPLACE_OPERATION), e);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java
@@ -97,6 +97,7 @@ public class HasMetadataOperation<T extends HasMetadata, L extends KubernetesRes
 
   @Override
   public T replace() {
+    System.out.println("mbc: in HasMetadataOperation::replace");
     return handleReplace(getItem());
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -179,14 +179,15 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImp
   }
   
   @Override
-  public List<HasMetadata> createOrReplaceWithFieldManager() {
+  public List<HasMetadata> createOrReplaceWithFieldManager(String fieldManager) {
     List<? extends Resource<HasMetadata>> operations = getResources();
 
     return operations.stream()
-        .map(Resource::createOrReplaceWithFieldManager)
+        .map(resource -> resource.createOrReplaceWithFieldManager(fieldManager))
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
+
 
   @Override
   public List<StatusDetails> delete() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImpl.java
@@ -177,6 +177,16 @@ public class NamespaceVisitFromServerGetWatchDeleteRecreateWaitApplicableListImp
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
+  
+  @Override
+  public List<HasMetadata> createOrReplaceWithFieldManager() {
+    List<? extends Resource<HasMetadata>> operations = getResources();
+
+    return operations.stream()
+        .map(Resource::createOrReplaceWithFieldManager)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
 
   @Override
   public List<StatusDetails> delete() {

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelper.java
@@ -72,7 +72,7 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
   }
 
   private T replace(T item, String resourceVersion) {
-    System.out.println("Trying to replace " + item.getMetadata().getName() + " with version " + resourceVersion);
+    System.out.println("mbc: Trying to replace " + item.getMetadata().getName() + " with version " + resourceVersion);
     KubernetesResourceUtil.setResourceVersion(item, resourceVersion);
     return replaceTask.apply(item);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelper.java
@@ -43,13 +43,11 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
 
   public T createOrReplace(T item) {
     String resourceVersion = KubernetesResourceUtil.getResourceVersion(item);
-    System.out.println("mbc: Got resourceVersion " + resourceVersion);
     final CompletableFuture<T> future = new CompletableFuture<>();
     int nTries = 0;
     item = serialization.clone(item);
     while (!future.isDone() && nTries < CREATE_OR_REPLACE_RETRIES) {
       try {
-        System.out.println("mbc: Trying to create or replace " + item.getMetadata().getName() + " attempt " + nTries);
         // Create
         KubernetesResourceUtil.setResourceVersion(item, null);
         return createTask.apply(item);
@@ -64,7 +62,6 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
         } else if (exception.getCode() != HttpURLConnection.HTTP_CONFLICT) {
           throw exception;
         }
-        System.out.println("mbc: Giving up on create, going to replace instead.");
         future.complete(replace(item, resourceVersion));
       }
     }
@@ -72,7 +69,6 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
   }
 
   private T replace(T item, String resourceVersion) {
-    System.out.println("mbc: Trying to replace " + item.getMetadata().getName() + " with version " + resourceVersion);
     KubernetesResourceUtil.setResourceVersion(item, resourceVersion);
     return replaceTask.apply(item);
   }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelper.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/utils/internal/CreateOrReplaceHelper.java
@@ -43,11 +43,13 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
 
   public T createOrReplace(T item) {
     String resourceVersion = KubernetesResourceUtil.getResourceVersion(item);
+    System.out.println("mbc: Got resourceVersion " + resourceVersion);
     final CompletableFuture<T> future = new CompletableFuture<>();
     int nTries = 0;
     item = serialization.clone(item);
     while (!future.isDone() && nTries < CREATE_OR_REPLACE_RETRIES) {
       try {
+        System.out.println("mbc: Trying to create or replace " + item.getMetadata().getName() + " attempt " + nTries);
         // Create
         KubernetesResourceUtil.setResourceVersion(item, null);
         return createTask.apply(item);
@@ -62,7 +64,7 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
         } else if (exception.getCode() != HttpURLConnection.HTTP_CONFLICT) {
           throw exception;
         }
-
+        System.out.println("mbc: Giving up on create, going to replace instead.");
         future.complete(replace(item, resourceVersion));
       }
     }
@@ -70,6 +72,7 @@ public class CreateOrReplaceHelper<T extends HasMetadata> {
   }
 
   private T replace(T item, String resourceVersion) {
+    System.out.println("Trying to replace " + item.getMetadata().getName() + " with version " + resourceVersion);
     KubernetesResourceUtil.setResourceVersion(item, resourceVersion);
     return replaceTask.apply(item);
   }


### PR DESCRIPTION
The current implementation doesn't set the field manager at all on these calls, which leads to a default being constructed from the user-agent string when they're made from the context of the kubectl-operators CLI.

Rather than mess around with the user-agent, this PR adds a method to set the field manager manually by adding it as a query parameter.

This works and has been tested with kubectl-operators, but currently duplicates a lot of code and lacks the retrying logic from the existing `replace()` [command](https://github.com/HubSpot/kubernetes-client/blob/6.13.4-hubspot/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/HasMetadataOperation.java#L152-L210), so it's not complete in its current state.

I am not sure if I should port the rest of the existing `replace` (and `create`) logic to this new method, or if I should try to more deeply integrate my changes with the existing code.

