### PR TITLE
Add `fieldManagerDefault` configuration option + set field manager on non-SSA operations

### DIFF
--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -157,7 +157,7 @@ public class Config {
   private Boolean trustCerts;
   private Boolean disableHostnameVerification;
   private String masterUrl;
-  private String fieldManagerOverride;
+  private String fieldManagerDefault;
   private String apiVersion;
   private String namespace;
   private Boolean defaultNamespace;
@@ -1349,13 +1349,13 @@ public class Config {
     this.masterUrl = ensureEndsWithSlash(ensureHttps(masterUrl, this));
   }
 
-  @JsonProperty("fieldManagerOverride")
-  public String getFieldManagerOverride() {
-    return fieldManagerOverride;
+  @JsonProperty("fieldManagerDefault")
+  public String getFieldManagerDefault() {
+    return fieldManagerDefault;
   }
 
-  public void setFieldManagerOverride(String fieldManagerOverride) {
-    this.fieldManagerOverride = fieldManagerOverride;
+  public void setFieldManagerDefault(String fieldManagerDefault) {
+    this.fieldManagerDefault = fieldManagerDefault;
   }
 
   @JsonProperty("trustCerts")

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -1354,8 +1354,8 @@ public class Config {
     return fieldManagerOverride;
   }
 
-  public void setFieldManagerOverride(String filedManagerOverride) {
-    this.fieldManagerOverride = filedManagerOverride;
+  public void setFieldManagerOverride(String fieldManagerOverride) {
+    this.fieldManagerOverride = fieldManagerOverride;
   }
 
   @JsonProperty("trustCerts")

--- a/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
+++ b/kubernetes-client-api/src/main/java/io/fabric8/kubernetes/client/Config.java
@@ -157,6 +157,7 @@ public class Config {
   private Boolean trustCerts;
   private Boolean disableHostnameVerification;
   private String masterUrl;
+  private String fieldManagerOverride;
   private String apiVersion;
   private String namespace;
   private Boolean defaultNamespace;
@@ -1346,6 +1347,15 @@ public class Config {
     //We set the masterUrl because it's needed by ensureHttps
     this.masterUrl = masterUrl;
     this.masterUrl = ensureEndsWithSlash(ensureHttps(masterUrl, this));
+  }
+
+  @JsonProperty("fieldManagerOverride")
+  public String getFieldManagerOverride() {
+    return fieldManagerOverride;
+  }
+
+  public void setFieldManagerOverride(String filedManagerOverride) {
+    this.fieldManagerOverride = filedManagerOverride;
   }
 
   @JsonProperty("trustCerts")

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -300,7 +300,7 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public final T createOrReplace() {
-    System.out.println("Version: 2, in createOrReplace");
+    System.out.println("Version: 3, in createOrReplace");
     System.out.println("fieldManagerOverride: " + config.getFieldManagerOverride());
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -300,8 +300,6 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public final T createOrReplace() {
-    System.out.println("Version: 3, in createOrReplace");
-    System.out.println("fieldManagerOverride: " + config.getFieldManagerOverride());
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/BaseOperation.java
@@ -300,6 +300,8 @@ public class BaseOperation<T extends HasMetadata, L extends KubernetesResourceLi
 
   @Override
   public final T createOrReplace() {
+    System.out.println("Version: 2, in createOrReplace");
+    System.out.println("fieldManagerOverride: " + config.getFieldManagerOverride());
     if (item == null) {
       throw new IllegalArgumentException("Nothing to create.");
     }

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -204,6 +204,10 @@ public class OperationSupport {
       resourceURL = new URL(
           URLUtils.join(resourceURL.toString(), "?fieldValidation=" + context.fieldValidation.parameterValue()));
     }
+    if (config.getFieldManagerOverride() != null) {
+      resourceURL = new URLUtils.URLBuilder(resourceURL).addQueryParameter("fieldManager", config.getFieldManagerOverride()).build();
+    }
+
     return resourceURL;
   }
 
@@ -227,6 +231,9 @@ public class OperationSupport {
       }
       if (fieldManager == null && patchContext.getPatchType() == PatchType.SERVER_SIDE_APPLY) {
         fieldManager = "fabric8";
+      }
+      if (fieldManager == null && patchContext.getPatchType() != PatchType.SERVER_SIDE_APPLY && config.getFieldManagerOverride() != null) {
+        fieldManager = config.getFieldManagerOverride();
       }
       if (fieldManager != null) {
         url = URLUtils.join(url, FIELD_MANAGER_PARAM + fieldManager);
@@ -334,9 +341,10 @@ public class OperationSupport {
    */
   protected <T, I> T handleCreate(I resource, Class<T> outputType) throws InterruptedException, IOException {
     resource = correctNamespace(resource);
+    URL resourceUrl = getResourceURLForWriteOperation(getResourceUrl(checkNamespace(resource), null));
     HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
         .post(JSON, getKubernetesSerialization().asJson(resource))
-        .url(getResourceURLForWriteOperation(getResourceUrl(checkNamespace(resource), null)));
+        .url(resourceUrl);
     return handleResponse(requestBuilder, outputType);
   }
 
@@ -354,16 +362,7 @@ public class OperationSupport {
     updated = correctNamespace(updated);
 
     URL resourceUrl = getResourceURLForWriteOperation(getResourceUrl(checkNamespace(updated), checkName(updated)));
-    if (config.getFieldManagerOverride() != null) {
-      // TODO: Can probably do this with methods on URL rather than string concatenation
-      String url = resourceUrl.toString();
-      if (url.contains("?")) {
-        url += "&fieldManager=" + config.getFieldManagerOverride();
-      } else {
-        url += "?fieldManager=" + config.getFieldManagerOverride();
-      }
-      resourceUrl = new URL(url);
-    }
+
     System.out.println("mbc: In handleUpdate, resource URL: " + resourceUrl);
     HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
         .put(JSON, getKubernetesSerialization().asJson(updated))

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -205,7 +205,8 @@ public class OperationSupport {
           URLUtils.join(resourceURL.toString(), "?fieldValidation=" + context.fieldValidation.parameterValue()));
     }
     if (config.getFieldManagerOverride() != null) {
-      resourceURL = new URLUtils.URLBuilder(resourceURL).addQueryParameter("fieldManager", config.getFieldManagerOverride()).build();
+      resourceURL = new URL(
+        URLUtils.join(resourceURL.toString(), "?fieldManager=" + config.getFieldManagerOverride()));
     }
 
     return resourceURL;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -352,9 +352,22 @@ public class OperationSupport {
    */
   protected <T> T handleUpdate(T updated, Class<T> type) throws IOException {
     updated = correctNamespace(updated);
+
+    URL resourceUrl = getResourceURLForWriteOperation(getResourceUrl(checkNamespace(updated), checkName(updated)));
+    if (config.getFieldManagerOverride() != null) {
+      // TODO: Can probably do this with methods on URL rather than string concatenation
+      String url = resourceUrl.toString();
+      if (url.contains("?")) {
+        url += "&fieldManager=" + config.getFieldManagerOverride();
+      } else {
+        url += "?fieldManager=" + config.getFieldManagerOverride();
+      }
+      resourceUrl = new URL(url);
+    }
+    System.out.println("mbc: In handleUpdate, resource URL: " + resourceUrl);
     HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
         .put(JSON, getKubernetesSerialization().asJson(updated))
-        .url(getResourceURLForWriteOperation(getResourceUrl(checkNamespace(updated), checkName(updated))));
+        .url(resourceUrl);
     return handleResponse(requestBuilder, type);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -341,10 +341,9 @@ public class OperationSupport {
    */
   protected <T, I> T handleCreate(I resource, Class<T> outputType) throws InterruptedException, IOException {
     resource = correctNamespace(resource);
-    URL resourceUrl = getResourceURLForWriteOperation(getResourceUrl(checkNamespace(resource), null));
     HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
         .post(JSON, getKubernetesSerialization().asJson(resource))
-        .url(resourceUrl);
+        .url(getResourceURLForWriteOperation(getResourceUrl(checkNamespace(resource), null)));
     return handleResponse(requestBuilder, outputType);
   }
 
@@ -360,13 +359,9 @@ public class OperationSupport {
    */
   protected <T> T handleUpdate(T updated, Class<T> type) throws IOException {
     updated = correctNamespace(updated);
-
-    URL resourceUrl = getResourceURLForWriteOperation(getResourceUrl(checkNamespace(updated), checkName(updated)));
-
-    System.out.println("mbc: In handleUpdate, resource URL: " + resourceUrl);
     HttpRequest.Builder requestBuilder = httpClient.newHttpRequestBuilder()
         .put(JSON, getKubernetesSerialization().asJson(updated))
-        .url(resourceUrl);
+        .url(getResourceURLForWriteOperation(getResourceUrl(checkNamespace(updated), checkName(updated))));
     return handleResponse(requestBuilder, type);
   }
 

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -206,7 +206,7 @@ public class OperationSupport {
     }
     if (config.getFieldManagerOverride() != null) {
       resourceURL = new URL(
-        URLUtils.join(resourceURL.toString(), "?fieldManager=" + config.getFieldManagerOverride()));
+        URLUtils.join(resourceURL.toString(), FIELD_MANAGER_PARAM + config.getFieldManagerOverride()));
     }
 
     return resourceURL;

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -230,11 +230,11 @@ public class OperationSupport {
       if (fieldManager == null) {
         fieldManager = this.context.fieldManager;
       }
+      if (fieldManager == null && config.getFieldManagerOverride() != null) {
+        fieldManager = config.getFieldManagerOverride();
+      }
       if (fieldManager == null && patchContext.getPatchType() == PatchType.SERVER_SIDE_APPLY) {
         fieldManager = "fabric8";
-      }
-      if (fieldManager == null && patchContext.getPatchType() != PatchType.SERVER_SIDE_APPLY && config.getFieldManagerOverride() != null) {
-        fieldManager = config.getFieldManagerOverride();
       }
       if (fieldManager != null) {
         url = URLUtils.join(url, FIELD_MANAGER_PARAM + fieldManager);

--- a/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
+++ b/kubernetes-client/src/main/java/io/fabric8/kubernetes/client/dsl/internal/OperationSupport.java
@@ -204,9 +204,9 @@ public class OperationSupport {
       resourceURL = new URL(
           URLUtils.join(resourceURL.toString(), "?fieldValidation=" + context.fieldValidation.parameterValue()));
     }
-    if (config.getFieldManagerOverride() != null) {
+    if (config.getFieldManagerDefault() != null) {
       resourceURL = new URL(
-        URLUtils.join(resourceURL.toString(), FIELD_MANAGER_PARAM + config.getFieldManagerOverride()));
+        URLUtils.join(resourceURL.toString(), FIELD_MANAGER_PARAM + config.getFieldManagerDefault()));
     }
 
     return resourceURL;
@@ -230,8 +230,8 @@ public class OperationSupport {
       if (fieldManager == null) {
         fieldManager = this.context.fieldManager;
       }
-      if (fieldManager == null && config.getFieldManagerOverride() != null) {
-        fieldManager = config.getFieldManagerOverride();
+      if (fieldManager == null && config.getFieldManagerDefault() != null) {
+        fieldManager = config.getFieldManagerDefault();
       }
       if (fieldManager == null && patchContext.getPatchType() == PatchType.SERVER_SIDE_APPLY) {
         fieldManager = "fabric8";


### PR DESCRIPTION
Replaces https://github.com/HubSpot/kubernetes-client/pull/257.

For `PUT` operations, the client currently doesn't set a `?fieldManager` query parameter at all, which causes the API server to infer one from the User-Agent header, which leaves resources created with kubectl-operators with all their fields owned by `localhost-<pid>@<some macbook ID>`. This causes conflicts later when tools such as `k safe-apply` are used on the same objects.

To fix this we want to make kubectl-operators set the same field manager that `k safe-apply` uses, and this PR updates the kubernetes client to make that configurable.

In addition to `PUT`, this uses the same field manger override value for `PATCH` requests that are not of the server-side apply `PatchType`.

The behavior of server-side apply, which already provides an API for configuring the field manager, is unchanged in the case of a user providing a field manager via the `.withFieldManager` call. When a user does _not_ provide a field manager to a server-side apply operation, the client will use the `fieldManagerDefault` if it is set, otherwise it will use the existing default of `fabric8`.

I tested this manually with https://git.hubteam.com/HubSpot/kube-operators-tools/compare/build-with-fabric8-client-branch?expand=1 and verified that the client now sets the field manager with our provided default.
