### PR TITLE
support AdditionalPrinterColumn annotation in v1 generator

### DIFF
--- a/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractCustomResourceHandler.java
+++ b/crd-generator/api/src/main/java/io/fabric8/crd/generator/AbstractCustomResourceHandler.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.crd.generator;
 
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn;
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumns;
 import io.fabric8.crd.generator.decorator.Decorator;
 import io.fabric8.crd.generator.visitor.*;
 import io.fabric8.kubernetes.client.utils.Utils;
@@ -24,7 +26,9 @@ import io.sundr.model.Property;
 import io.sundr.model.TypeDef;
 import io.sundr.model.TypeDefBuilder;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -97,6 +101,10 @@ public abstract class AbstractCustomResourceHandler {
       resources.decorate(
           getPrinterColumnDecorator(name, version, path, type, column, description, format, priority));
     });
+
+    if(!maybeAddPrinterColumnDecoratorsFromSingleAnnotation(name, version, def)) {
+      maybeAddPrinterColumnDecoratorsFromRepeatableAnnotation(name, version, def);
+    }
   }
 
   private TypeDef visitTypeDef(TypeDef def, List<Visitor<TypeDefBuilder>> visitors) {
@@ -145,6 +153,211 @@ public abstract class AbstractCustomResourceHandler {
       executorService.shutdown();
     }
     return def;
+  }
+
+  private boolean maybeAddPrinterColumnDecoratorsFromSingleAnnotation(
+    String name,
+    String version,
+    TypeDef def
+  ) {
+    List<AnnotationRef> annotationRefs = def
+      .getAnnotations()
+      .stream()
+      .filter(annotationRef ->
+        annotationRef
+          .getClassRef()
+          .getName()
+          .equals(AdditionalPrinterColumn.class.getSimpleName())
+      )
+      .collect(Collectors.toList());
+
+    if (annotationRefs.isEmpty()) {
+      return false;
+    }
+
+    addPrinterColumnDecoratorsFromAnnotationRefs(
+      name,
+      version,
+      annotationRefs
+    );
+
+    return true;
+  }
+
+  private void addPrinterColumnDecoratorsFromAnnotationRefs(
+    String name,
+    String version,
+    List<AnnotationRef> columns
+  ) {
+    for (AnnotationRef column : columns) {
+      Map<String, Object> params = column.getParameters();
+
+      String path = (String) params.get("jsonPath");
+      if (Utils.isNullOrEmpty(path)) {
+        continue;
+      }
+
+      if (!params.containsKey("type")) {
+        continue;
+      }
+      String type = extractEnumValue(
+        params.get("type"),
+        AdditionalPrinterColumn.Type.class
+      )
+        .getValue();
+
+      String nameOfColumn = (String) params.get("name");
+      if (Utils.isNullOrEmpty(nameOfColumn)) {
+        nameOfColumn = generateColumnNameFromPath(path);
+      }
+
+      String description = (!params.containsKey("getDescription"))
+        ? getAdditionalPrinterColumnDefault("getDescription", String.class)
+        : (String) params.get("getDescription");
+
+      String format = (!params.containsKey("format"))
+        ? getAdditionalPrinterColumnDefault(
+        "format",
+        AdditionalPrinterColumn.Format.class
+      )
+        .getValue()
+        : extractEnumValue(params.get("format"), AdditionalPrinterColumn.Format.class)
+        .getValue();
+
+      int priority = (!params.containsKey("priority"))
+        ? getAdditionalPrinterColumnDefault("priority", Integer.class)
+        : (int) params.get("priority");
+
+      resources.decorate(
+        getPrinterColumnDecorator(
+          name,
+          version,
+          path,
+          type,
+          nameOfColumn,
+          description,
+          format,
+          priority
+        )
+      );
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T extends Enum<T>> T extractEnumValue(Object enumObject, Class<T> enumClass) {
+    if (enumObject instanceof Enum) {
+      return (T) enumObject;
+    }
+
+    String stringValue;
+    try {
+      stringValue =
+        enumObject.getClass().getMethod("getSimpleName").invoke(enumObject).toString();
+    } catch (
+      NoSuchMethodException | InvocationTargetException | IllegalAccessException e
+    ) {
+      throw new RuntimeException(e);
+    }
+    Optional<T> maybeEnumValue = Arrays
+      .stream(enumClass.getEnumConstants())
+      .filter(formatValue -> formatValue.name().equals(stringValue))
+      .findFirst();
+
+    if (!maybeEnumValue.isPresent()) {
+      throw new IllegalArgumentException(
+        "Unknown enum value for " + enumClass.getSimpleName() + ": " + stringValue
+      );
+    }
+
+    return maybeEnumValue.get();
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> T getAdditionalPrinterColumnDefault(
+    String methodName,
+    Class<T> returnType
+  ) {
+    try {
+      return (T) AdditionalPrinterColumn.class.getMethod(methodName).getDefaultValue();
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String generateColumnNameFromPath(String path) {
+    String[] splitPath = path.split("\\.");
+    return splitPath[splitPath.length - 1].replaceAll("\\W+", "_").toUpperCase();
+  }
+
+  private void maybeAddPrinterColumnDecoratorsFromRepeatableAnnotation(
+    String name,
+    String version,
+    TypeDef def
+  ) {
+    Optional<AnnotationRef> maybeRepeatableAnnotationRef = def
+      .getAnnotations()
+      .stream()
+      .filter(annotationRef ->
+        annotationRef
+          .getClassRef()
+          .getName()
+          .equals(AdditionalPrinterColumns.class.getSimpleName())
+      )
+      .findFirst();
+
+    if (!maybeRepeatableAnnotationRef.isPresent()) {
+      return;
+    }
+
+    Object innerAnnotationsObject = maybeRepeatableAnnotationRef
+      .get()
+      .getParameters()
+      .get("value");
+
+    if (innerAnnotationsObject instanceof AdditionalPrinterColumn[]) {
+      addPrinterColumnDecoratorsFromAdditionalPrinterColumns(
+        name,
+        version,
+        Arrays.asList((AdditionalPrinterColumn[]) innerAnnotationsObject)
+      );
+    } else {
+      addPrinterColumnDecoratorsFromAnnotationRefs(
+        name,
+        version,
+        Arrays.asList((AnnotationRef[]) innerAnnotationsObject)
+      );
+    }
+  }
+
+  private void addPrinterColumnDecoratorsFromAdditionalPrinterColumns(
+    String name,
+    String version,
+    List<AdditionalPrinterColumn> columns
+  ) {
+    for (AdditionalPrinterColumn column : columns) {
+      String path = column.jsonPath();
+      if (Utils.isNullOrEmpty(path)) {
+        continue;
+      }
+
+      String nameOfColumn = column.name();
+      if (Utils.isNullOrEmpty(nameOfColumn)) {
+        nameOfColumn = generateColumnNameFromPath(path);
+      }
+
+      resources.decorate(
+        getPrinterColumnDecorator(
+          name,
+          version,
+          path,
+          column.type().getValue(),
+          nameOfColumn,
+          column.getDescription(),
+          column.format().getValue(),
+          column.priority()
+        )
+      );
+    }
   }
 
   /**

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/AnotherJokeRequest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/AnotherJokeRequest.java
@@ -1,0 +1,17 @@
+package io.fabric8.crd.example.joke;
+
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn;
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn.Type;
+import io.fabric8.kubernetes.api.model.Namespaced;
+import io.fabric8.kubernetes.client.CustomResource;
+import io.fabric8.kubernetes.model.annotation.Group;
+import io.fabric8.kubernetes.model.annotation.ShortNames;
+import io.fabric8.kubernetes.model.annotation.Version;
+
+@Group("samples.javaoperatorsdk.io")
+@Version("v1alpha1")
+@ShortNames("ajr")
+@AdditionalPrinterColumn(name = "Age", jsonPath = ".metadata.creationTimestamp", type = Type.DATE)
+@AdditionalPrinterColumn(jsonPath = ".metadata.namespace")
+public class AnotherJokeRequest extends CustomResource<JokeRequestSpec, JokeRequestStatus> implements Namespaced {
+}

--- a/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/example/joke/JokeRequest.java
@@ -15,6 +15,8 @@
  */
 package io.fabric8.crd.example.joke;
 
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn;
+import io.fabric8.crd.generator.annotation.AdditionalPrinterColumn.Type;
 import io.fabric8.kubernetes.api.model.Namespaced;
 import io.fabric8.kubernetes.client.CustomResource;
 import io.fabric8.kubernetes.model.annotation.Group;
@@ -24,6 +26,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Group("samples.javaoperatorsdk.io")
 @Version("v1alpha1")
 @ShortNames("jr")
+@AdditionalPrinterColumn(name = "Age", jsonPath = ".metadata.creationTimestamp", type = Type.DATE)
 public class JokeRequest extends CustomResource<JokeRequestSpec, JokeRequestStatus> implements Namespaced {
 
 }

--- a/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
+++ b/crd-generator/api/src/test/java/io/fabric8/crd/generator/CRDGeneratorTest.java
@@ -27,6 +27,7 @@ import io.fabric8.crd.example.inherited.BaseStatus;
 import io.fabric8.crd.example.inherited.Child;
 import io.fabric8.crd.example.inherited.ChildSpec;
 import io.fabric8.crd.example.inherited.ChildStatus;
+import io.fabric8.crd.example.joke.AnotherJokeRequest;
 import io.fabric8.crd.example.joke.Joke;
 import io.fabric8.crd.example.joke.JokeRequest;
 import io.fabric8.crd.example.joke.JokeRequestSpec;
@@ -426,18 +427,23 @@ class CRDGeneratorTest {
       // printer columns should be ordered in the alphabetical order of their json path
       final List<CustomResourceColumnDefinition> printerColumns = version
           .getAdditionalPrinterColumns();
-      assertEquals(3, printerColumns.size());
+      assertEquals(4, printerColumns.size());
       CustomResourceColumnDefinition columnDefinition = printerColumns.get(0);
+      assertEquals("date", columnDefinition.getType());
+      assertEquals(".metadata.creationTimestamp", columnDefinition.getJsonPath());
+      assertEquals("Age", columnDefinition.getName());
+      assertEquals(0, columnDefinition.getPriority());
+      columnDefinition = printerColumns.get(1);
       assertEquals("string", columnDefinition.getType());
       assertEquals(".spec.category", columnDefinition.getJsonPath());
       assertEquals("jokeCategory", columnDefinition.getName());
       assertEquals(1, columnDefinition.getPriority());
-      columnDefinition = printerColumns.get(1);
+      columnDefinition = printerColumns.get(2);
       assertEquals("string", columnDefinition.getType());
       assertEquals(".spec.excluded", columnDefinition.getJsonPath());
       assertEquals("excludedTopics", columnDefinition.getName());
       assertEquals(0, columnDefinition.getPriority());
-      columnDefinition = printerColumns.get(2);
+      columnDefinition = printerColumns.get(3);
       assertEquals("string", columnDefinition.getType());
       assertEquals(".status.category", columnDefinition.getJsonPath());
       assertEquals("jokeCategory", columnDefinition.getName());
@@ -457,6 +463,37 @@ class CRDGeneratorTest {
       assertEquals("array", excluded.getType());
       assertEquals("string", excluded.getItems().getSchema().getType());
       assertEquals(6, excluded.getItems().getSchema().getEnum().size());
+    });
+  }
+
+  @Test
+  void anotherJokeRequestShouldProcessTwoPrinterColumns() {
+    outputCRDIfFailed(AnotherJokeRequest.class, (customResource) -> {
+      final CustomResourceDefinitionSpec spec = checkSpec(customResource, Scope.NAMESPACED,
+        JokeRequestSpec.class, JokeRequestStatus.class, JokeRequestSpec.Category.class, JokeRequestSpec.ExcludedTopic.class,
+        JokeRequestStatus.State.class);
+
+      final CustomResourceDefinitionNames names = checkNames("AnotherJokeRequest",
+        "anotherjokerequests", spec);
+      assertEquals(1, names.getShortNames().size());
+      assertTrue(names.getShortNames().contains("ajr"));
+
+      final CustomResourceDefinitionVersion version = checkVersion(spec);
+      assertNotNull(version.getSubresources());
+      // printer columns should be ordered in the alphabetical order of their json path
+      final List<CustomResourceColumnDefinition> printerColumns = version
+        .getAdditionalPrinterColumns();
+      assertEquals(5, printerColumns.size());
+      CustomResourceColumnDefinition columnDefinition = printerColumns.get(0);
+      assertEquals("date", columnDefinition.getType());
+      assertEquals(".metadata.creationTimestamp", columnDefinition.getJsonPath());
+      assertEquals("Age", columnDefinition.getName());
+      assertEquals(0, columnDefinition.getPriority());
+      columnDefinition = printerColumns.get(1);
+      assertEquals("string", columnDefinition.getType());
+      assertEquals(".metadata.namespace", columnDefinition.getJsonPath());
+      assertEquals("NAMESPACE", columnDefinition.getName());
+      assertEquals(0, columnDefinition.getPriority());
     });
   }
 

--- a/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
+++ b/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumn.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Defines an additional printer column. Must be placed at the root of the
+ * custom resource.
+ */
+@Repeatable(AdditionalPrinterColumns.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdditionalPrinterColumn {
+
+  //https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#type
+  enum Type {
+
+    STRING("string"),
+    INTEGER("integer"),
+    NUMBER("number"),
+    BOOLEAN("boolean"),
+    DATE("date");
+
+    public final String value;
+
+    Type(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
+  // https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#format
+  enum Format {
+
+    NONE(""),
+    INT32("int32"),
+    INT64("int64"),
+    FLOAT("float"),
+    DOUBLE("double"),
+    BYTE("byte"),
+    DATE("date"),
+    DATE_TIME("date-time"),
+    PASSWORD("password");
+
+    public final String value;
+
+    Format(String value) {
+      this.value = value;
+    }
+
+    public String getValue() {
+      return value;
+    }
+  }
+
+  /**
+   * The name of the column. An empty column name implies the use of the last path
+   * element
+   *
+   * @return the column name, or empty string if the last path element should be
+   *         used.
+   */
+  String name() default "";
+
+  /**
+   * The printer column format.
+   *
+   * @return the format or NONE if no format is specified.
+   */
+  Format format() default Format.NONE;
+
+  /**
+   * The printer column priority.
+   *
+   * @return the priority or 0 if no priority is specified.
+   */
+  int priority() default 0;
+
+  /**
+   * The JSON Path to the field
+   * 
+   * @return
+   */
+  String jsonPath();
+
+  /**
+   * The type of the printer column
+   * 
+   * @return the type
+   */
+  Type type() default Type.STRING;
+
+  /**
+   * The description of the printer column
+   * 
+   * @return the description
+   */
+  String getDescription() default "";
+}

--- a/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumns.java
+++ b/generator-annotations/src/main/java/io/fabric8/crd/generator/annotation/AdditionalPrinterColumns.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.fabric8.crd.generator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * A container for multiple {@link AdditionalPrinterColumn}s
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdditionalPrinterColumns {
+  AdditionalPrinterColumn[] value();
+}


### PR DESCRIPTION
Supports adding arbitrary additional printer columns to the v1 version of the CRD generator, using the same annotations that will be eventually used when we port over to the v2 version of the generator.

Throughout the added code, we have to support two cases:
- The runtime environment where the unit tests are running, where the parameters of the `AnnotationRefs` are actual types, and;
- The compile time environment where the parameters of the `AnnotationsRefs` are AST symbols and other referential forms.  This makes getting defaults and extracting enum values much more complicated (done here through reflection).  

Relates to https://git.hubteam.com/HubSpot/kube-operators/issues/10049

