### PR TITLE
Include `java-generator-core` in build

### DIFF
--- a/.blazar.yaml
+++ b/.blazar.yaml
@@ -6,7 +6,7 @@ enabled: true
 env:
   SET_VERSION_OVERRIDE: $GIT_BRANCH-SNAPSHOT
   MAVEN_OPTS: -Xmx4096m
-  MAVEN_BUILD_ARGS: -DskipTests -am -pl junit/kubernetes-server-mock,kubernetes-model-generator,kubernetes-client,kubernetes-client-api,httpclient-okhttp,crd-generator/api,crd-generator/apt,generator-annotations
+  MAVEN_BUILD_ARGS: -DskipTests -am -pl junit/kubernetes-server-mock,kubernetes-model-generator,kubernetes-client,kubernetes-client-api,httpclient-okhttp,crd-generator/api,crd-generator/apt,generator-annotations,java-generator/core
 
 buildResources:
   cpus: 2


### PR DESCRIPTION
We're writing an internal [Mill plugin](https://mill-build.org/mill/extending/thirdparty-plugins.html) for CRD -> Java POJO generation, so we need to build `java-generator-core`.